### PR TITLE
PostgreSQL - serial pseudotype support

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -522,7 +522,7 @@ AND typelem = 0"
 	$types = array();
 	$structured_types = array();
 	foreach (array( //! arrays
-		lang('Numbers') => array("smallint" => 5, "integer" => 10, "bigint" => 19, "boolean" => 1, "numeric" => 0, "real" => 7, "double precision" => 16, "money" => 20),
+		lang('Numbers') => array("smallint" => 5, "integer" => 10, "bigint" => 19, "boolean" => 1, "numeric" => 0, "real" => 7, "double precision" => 16, "money" => 20, 'serial' => 10),
 		lang('Date and time') => array("date" => 13, "time" => 17, "timestamp" => 20, "interval" => 0),
 		lang('Strings') => array("character" => 0, "character varying" => 0, "text" => 0, "tsquery" => 0, "tsvector" => 0, "uuid" => 0, "xml" => 0),
 		lang('Binary') => array("bit" => 0, "bit varying" => 0, "bytea" => 0),


### PR DESCRIPTION
SERIAL pseudotype is useful for quite every creation of table. It will be nice if Adminer will have support for it.
