### PR TITLE
Properly display value of type bit (from MySQL)

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -205,6 +205,11 @@ username.form['auth[driver]'].onchange();
 	* @return string
 	*/
 	function editVal($val, $field) {
+		if ($val === "\0") {
+			return '0';
+		} elseif ($val === "\1") {
+			return '1';
+		}
 		return $val;
 	}
 	

--- a/adminer/include/editing.inc.php
+++ b/adminer/include/editing.inc.php
@@ -57,6 +57,10 @@ function select($result, $connection2 = null, $href = "", $orgtables = array()) 
 		foreach ($row as $key => $val) {
 			if ($val === null) {
 				$val = "<i>NULL</i>";
+			} elseif ($val === "\0") {
+				$val = "<i>0</i>";
+			} elseif ($val === "\1") {
+				$val = "<i>1</i>";
 			} elseif ($blobs[$key] && !is_utf8($val)) {
 				$val = "<i>" . lang('%d byte(s)', strlen($val)) . "</i>"; //! link to download
 			} elseif (!strlen($val)) { // strlen - SQLite can return int

--- a/editor/include/adminer.inc.php
+++ b/editor/include/adminer.inc.php
@@ -187,6 +187,10 @@ ORDER BY ORDINAL_POSITION", null, "") as $row) { //! requires MySQL 5
 	function editVal($val, $field) {
 		if (ereg('date|timestamp', $field["type"]) && $val !== null) {
 			return preg_replace('~^(\\d{2}(\\d+))-(0?(\\d+))-(0?(\\d+))~', lang('$1-$3-$5'), $val);
+		} elseif ($val === "\0") {
+			return 'No';
+		} elseif ($val === "\1") {
+			return 'Yes';
 		}
 		return $val;
 	}


### PR DESCRIPTION
MySQL has column type of _bit_ which returns binary zero (`\0`) or binary one (`\1`), which is not properly displayed - both of these chars aren't renderable and thus appear as empty column.
