### PR TITLE
Sync MySQL time zone to that of PHP.

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -30,6 +30,7 @@ if (!defined("DRIVER")) {
 					} else {
 						$this->query("SET NAMES utf8");
 					}
+					$this->query("SET time_zone = '" . date('P') . "'");
 				}
 				return $return;
 			}
@@ -79,6 +80,7 @@ if (!defined("DRIVER")) {
 					} else {
 						$this->query("SET NAMES utf8");
 					}
+					$this->query("SET time_zone = '" . date('P') . "'");
 				} else {
 					$this->error = mysql_error();
 				}


### PR DESCRIPTION
Without a custom configuration, MySQL is not aware of daylight saving times. It is a best practice for a PHP software to set the same timezone for both PHP and MySQL. Leaving PHP timezone setting to the users of Adminer, I suggest to sync MySQL time zone to that of PHP.
