### PR TITLE
Disabling autocomplete on text inputs

### DIFF
--- a/adminer/static/editing.js
+++ b/adminer/static/editing.js
@@ -36,6 +36,11 @@ function bodyLoad(version) {
 		};
 		document.body.appendChild(script);
 	}
+	for (var i=0; i < document.getElementsByTagName('input').length; i++) {
+		if (document.getElementsByTagName('input').item(i).type == 'text') {
+			document.getElementsByTagName('input').item(i).setAttribute('autocomplete', 'off');
+		};
+	};
 }
 
 /** Get value of dynamically created form field


### PR DESCRIPTION
Hi, on certain browsers (IE9, Safari) the autocomplete feature does not trigger "onchange" event.
As a result, fields which are autocompleted are inserted as NULL by Adminer.
I suggest to disable autocomplete feature when using Adminer.
Another way to go would be to fix the event handling, but that seems a much bigger change.
