### PR TITLE
PostgreSQL Auto Increment/DEFAULT values fix

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -377,7 +377,7 @@ ORDER BY conkey, conname") as $row) {
 					}
 					$alter[] = "ALTER $column TYPE$val[1]";
 					if (!$val[6]) {
-						if (preg_match('~^\s+DEFAULT\s+\'nextval\\(\'\'(.*)\'\'\\)\'\s*$~', $val[3], $match)) {
+						if (preg_match('~^ DEFAULT \'\s*nextval\\(\'\'(.*)\'\'\\)\s*\'$~', $val[3], $match)) {
 							$default = " DEFAULT nextval('$match[1]')";
 						}
 						else {


### PR DESCRIPTION
Added right brace to view of default value in Auto Increment columns. Added
option to set `nextval('sequence_name')` as DEFAULT value on column.

Unfortunately, I realized that pattern in second change:
`~^\s+DEFAULT\s+\'nextval\\(\'\'(.*)\'\'\\)\'\s*$~`
should be changed to:
`~^ DEFAULT \'\s*nextval\\(\'\'(.*)\'\'\\)\s*\'$~`
to allow whitespace at start and end (that's because there are two commits).
