### PR TITLE
when showing data in table, use the column name, even if it has a column comment

### DIFF
--- a/adminer/select.inc.php
+++ b/adminer/select.inc.php
@@ -302,8 +302,11 @@ if (!$columns && support("table")) {
 						$href = remove_from_uri('(order|desc)[^=]*|page') . '&order%5B0%5D=' . urlencode($key);
 						$desc = "&desc%5B0%5D=1";
 						echo '<th onmouseover="columnMouse(this);" onmouseout="columnMouse(this, \' hidden\');">';
-						echo '<a href="' . h($href . ($order[0] == $column || $order[0] == $key || (!$order && $is_group && $group[0] == $column) ? $desc : '')) . '">'; // $order[0] == $key - COUNT(*)
-						echo apply_sql_function($val["fun"], $name) . "</a>"; //! columns looking like functions
+						if (isset($field['comment']) && $field['comment'] != '') {
+						  echo '<a title="'.$field['comment'].'">?</a> ';
+						}
+						echo '<a title="'.$field['comment'].'" href="' . h($href . ($order[0] == $column || $order[0] == $key || (!$order && $is_group && $group[0] == $column) ? $desc : '')) . '">'; // $order[0] == $key - COUNT(*)
+						echo apply_sql_function($val["fun"], $field['field']) . "</a>"; //! columns looking like functions
 						echo "<span class='column hidden'>";
 						echo "<a href='" . h($href . $desc) . "' title='" . lang('descending') . "' class='text'> ↓</a>";
 						if (!$val["fun"]) {

--- a/editor/include/adminer.inc.php
+++ b/editor/include/adminer.inc.php
@@ -65,11 +65,11 @@ focus(document.getElementById('username'));
 	}
 
 	function tableName($tableStatus) {
-		return h($tableStatus["Comment"] != "" ? $tableStatus["Comment"] : $tableStatus["Name"]);
+		return h($tableStatus["Name"]);
 	}
 
 	function fieldName($field, $order = 0) {
-		return h($field["comment"] != "" ? $field["comment"] : $field["field"]);
+		return h($field["field"]);
 	}
 
 	function selectLinks($tableStatus, $set = "") {


### PR DESCRIPTION
... in the table header, and instead show a question mark with tooltip that will show the column comment.
Also changed to show the table and columns directly instead of the comments, when displaying in other places.
