### PR TITLE
[Quick and critical] Fix incorrect column length extraction when altering a table

### DIFF
--- a/adminer/include/editing.inc.php
+++ b/adminer/include/editing.inc.php
@@ -164,7 +164,7 @@ function process_length($length) {
 	global $enum_length;
 	return (preg_match("~^\\s*\\(?\\s*$enum_length(?:\\s*,\\s*$enum_length)*+\\s*\\)?\\s*\$~", $length) && preg_match_all("~$enum_length~", $length, $matches)
 		? "(" . implode(",", $matches[0]) . ")"
-		: preg_replace('~[^-0-9,+()[\]]~', '', preg_replace('~^[0-9]+~', '(\1)', $length))
+		: preg_replace('~[^-0-9,+()[\]]~', '', preg_replace('~^(\d+)~', '(\1)', $length))
 	);
 }
 


### PR DESCRIPTION
The bug causes generating `varchar ()` instead of e.g. `varchar(20)`.
