### PR TITLE
Add fix for privilege whitespace

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -463,7 +463,7 @@ if (!defined("DRIVER")) {
 				"auto_increment" => ($row["Extra"] == "auto_increment"),
 				"on_update" => (preg_match('~^on update (.+)~i', $row["Extra"], $match) ? $match[1] : ""), //! available since MySQL 5.1.23
 				"collation" => $row["Collation"],
-				"privileges" => array_flip(explode(",", $row["Privileges"])),
+				"privileges" => array_flip(array_map('trim', explode(",", $row["Privileges"]))),
 				"comment" => $row["Comment"],
 				"primary" => ($row["Key"] == "PRI"),
 			);


### PR DESCRIPTION
When using adminer with Clustrix the fields function breaks because there are leading spaces, no bueno.
