### PR TITLE
MongoDB: show value of _id field instead of class name

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -56,12 +56,13 @@ if (isset($_GET["mongo"])) {
 							$this->_charset[$key] = 63;
 						}
 						$row[$key] =
+							(is_a($val, 'MongoId') ? 'ObjectId("' . strval($val) . '")':
 							(is_a($val, 'MongoDate') ? gmdate("Y-m-d H:i:s", $val->sec) . " GMT" :
 							(is_a($val, 'MongoBinData') ? $val->bin : //! allow downloading
 							(is_a($val, 'MongoRegex') ? strval($val) :
 							(is_object($val) ? get_class($val) : // MongoMinKey, MongoMaxKey
 							$val
-						))));
+						)))));
 					}
 					$this->_rows[] = $row;
 					foreach ($row as $key => $val) {


### PR DESCRIPTION
Hello Jakub,

this pull request corrects display of `_id` field.

If `_id` has `MongoId` type, it will be showed as `ObjectId("123456789012345678901234")` instead of string `MongoId`.
