### PR TITLE
Elasticsearch: improve driver

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -211,9 +211,9 @@ if (isset($_GET["elastic"])) {
 		if ($return) {
 			foreach ($return as $key => $type) { // _stats have just info about database
 				$return[$key] = array("Name" => $key, "Engine" => $type);
-				if ($name != "") {
-					return $return[$name];
-				}
+			}
+			if ($name != "") {
+				return $return[$name];
 			}
 		}
 		return $return;


### PR DESCRIPTION
Hello Jakub,

here is implementation of ES missing functions `create_database()`, `drop_databases()`, `drop_tables()`, and fix for function `tables_status()`.

Implementation of drop_tables function is not suitable (`n` requests over `n` types), unfortunately ES API does not allow query `DELETE /index/typeA,typeB/`
