### PR TITLE
Elasticsearch: fix function `get_databases()` via new function `rootQuery()`

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -9,9 +9,15 @@ if (isset($_GET["elastic"])) {
 		class Min_DB {
 			var $extension = "JSON", $server_info, $errno, $error, $_url;
 
-			function query($path, $content = array(), $method = 'GET') {
+			/** Performs query
+			 * @param string
+			 * @param array
+			 * @param string
+			 * @return mixed
+			 */
+			function rootQuery($path, $content = array(), $method = 'GET') {
 				@ini_set('track_errors', 1); // @ - may be disabled
-				$file = @file_get_contents($this->_url . ($this->_db != "" ? "$this->_db/" : "") . $path, false, stream_context_create(array('http' => array(
+				$file = @file_get_contents($this->_url  . '/' . ltrim($path, '/'), false, stream_context_create(array('http' => array(
 					'method' => $method,
 					'content' => json_encode($content),
 					'ignore_errors' => 1, // available since PHP 5.2.10
@@ -40,6 +46,16 @@ if (isset($_GET["elastic"])) {
 					}
 				}
 				return $return;
+			}
+
+			/** Performs query relative to actual selected DB
+			 * @param string
+			 * @param array
+			 * @param string
+			 * @return mixed
+			 */
+			function query($path, $content = array(), $method = 'GET') {
+				return $this->rootQuery(($this->_db != "" ? "$this->_db/" : "/") . ltrim($path, '/'), $content, $method);
 			}
 
 			function connect($server, $username, $password) {
@@ -174,7 +190,7 @@ if (isset($_GET["elastic"])) {
 
 	function get_databases() {
 		global $connection;
-		$return = $connection->query('_aliases');
+		$return = $connection->rootQuery('_aliases');
 		if ($return) {
 			$return = array_keys($return);
 		}
@@ -285,7 +301,7 @@ if (isset($_GET["elastic"])) {
 	*/
 	function create_database($db) {
 		global $connection;
-		return $connection->query(urlencode($db), array(), 'PUT');
+		return $connection->rootQuery(urlencode($db), array(), 'PUT');
 	}
 
 	/** Drop databases
@@ -294,7 +310,7 @@ if (isset($_GET["elastic"])) {
 	*/
 	function drop_databases($databases) {
 		global $connection;
-		return $connection->query(urlencode(implode(',', $databases)), array(), 'DELETE');
+		return $connection->rootQuery(urlencode(implode(',', $databases)), array(), 'DELETE');
 	}
 
 	/** Drop tables


### PR DESCRIPTION
Zdravím Jakube,

bylo potřeba rozšířit ES driver o možnost volat `query()` i oproti rootu URL, i když je zvolená DB (např. kvůli výpisu dostupných DB). Jen jsem si nebyl jist kterou cestou jít, aby to pro tebe bylo vhodné - osobně jsem preferoval cestu nové metody, neboť čtvrtý parameter u původní `query()` metody mi již přišel znepřehledňující. Pokud by jsi si implementaci představoval jinak, není problém to případně upravit... :-)

PS: omlouvám se za češtinu, ale tady už bych si překladově nebyl jist, tak raději aby aby nevzniklo nějaké faux pas...
