### PR TITLE
MongoDB: removed iterator to array conversion

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -130,12 +130,12 @@ if (isset($_GET["mongo"])) {
 				$val = preg_replace('~ DESC$~', '', $val, 1, $count);
 				$sort[$val] = ($count ? -1 : 1);
 			}
-			return new Min_Result(iterator_to_array($this->_conn->_db->selectCollection($table)
+			return new Min_Result($this->_conn->_db->selectCollection($table)
 				->find(array(), $select)
 				->sort($sort)
 				->limit(+$limit)
 				->skip($page * $limit)
-			));
+			);
 		}
 		
 		function insert($table, $set) {


### PR DESCRIPTION
Hello Jakub,

If there are rows with same `_id` value, but different type, calling `iterator_to_array` cause row lose and to `Min_Result` is passed only `1` row instead of `2`.

Sample documents:

``` json
{ "_id" : 10 }
{ "_id" : "10" }
```

Thanks.
