### PR TITLE
Added limit where it should stop creating a select

### DIFF
--- a/plugins/edit-foreign.php
+++ b/plugins/edit-foreign.php
@@ -8,6 +8,8 @@
 */
 class AdminerEditForeign {
 	
+	const LIMIT = 50;
+	
 	function editInput($table, $field, $attrs, $value) {
 		static $foreignTables = array();
 		static $values = array();
@@ -21,6 +23,10 @@ class AdminerEditForeign {
 				$id = $foreignKey["target"][0];
 				$options = &$values[$target][$id];
 				if (!$options) {
+					$count = get_vals(count_rows($target, array(), false, null));
+					if($count[0] > self::LIMIT) {
+						return;
+					}
 					$options = array("" => "") + get_vals("SELECT " . idf_escape($id) . " FROM " . table($target) . " ORDER BY 1");
 				}
 				return "<select$attrs>" . optionlist($options, $value) . "</select>";


### PR DESCRIPTION
My browser would often crash when loading the list of options from a foreign table. With this patch a maximum of 50 is shown and otherwise no change is done to the view. The 50 can easily be changed to another number by changing the LIMIT constant.
