### PR TITLE
Use null instead of ini values for mysqli connection, when running HHVM.

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -16,6 +16,18 @@ if (!defined("DRIVER")) {
 			function connect($server, $username, $password) {
 				mysqli_report(MYSQLI_REPORT_OFF); // stays between requests, not required since PHP 5.3.4
 				list($host, $port) = explode(":", $server, 2); // part after : is used for port or socket
+				if (defined('HHVM_VERSION')) {
+					$return = @$this->real_connect(
+						($server != "" ? $host : null),
+						($server . $username != "" ? $username : null),
+						($server . $username . $password != "" ? $password : null),
+						null,
+						(is_numeric($port) ? $port : null),
+						(!is_numeric($port) ? $port : null)
+
+					return $return;
+				}
+
 				$return = @$this->real_connect(
 					($server != "" ? $host : ini_get("mysqli.default_host")),
 					($server . $username != "" ? $username : ini_get("mysqli.default_user")),


### PR DESCRIPTION
HHVM was returning a boolean from ini_get() for some reason, which caused the page to turn blank.
Now it is using null instead, only when running HHVM.
I don't know if you want to keep on using the ini_values for normal php, because I think it does use the ini_values now too.
I'm not even sure if you want to add an exception for when running HHVM, but I thought it's worth a PR.
