### PR TITLE
Fix missing primary_key in haekel theme custom SQL execution

### DIFF
--- a/designs/haeckel/adminer.css
+++ b/designs/haeckel/adminer.css
@@ -146,8 +146,13 @@ html>/**/body table a[href*="&edit="][href*="&where"] {
     height: 16px;
     overflow: hidden;
     padding-left: 24px;
+}
+
+/* Hide text in automatic selects */
+html>/**/body form>table a[href*="&edit="][href*="&where"] {
     width: 0;
 }
+
 /* Select data */
 html>/**/body #menu p a[href*="&select="], html>/**/body .links a[href*="&select="] {
     background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAdVJREFUeNqck8tO21AQhn8bB8ehRe0SUEBOlIsSVFGqqlK3oey6K+9A96wTKU/RFU/AG7CrKhAg7gmKiJKIplFWqItWIQEfuzOT2LmsSo408j+2/5lvjo+1rULhM4AFTLfahuu6i3vF4rdp3F/y+W3DVUrzKNk8BTzPC4IKS3h8Hc0Hz49zr8BeXSml8wu8PsU1uW7EhjpHOmd7wX1fs4e9hnIcTUkBDfs1DzGjS5N1pPOGRR3bLjR6ztoNNJm9ebDXcBxnjMD99YCdzGvJT25v8T6ZFH1QLuNjNiv6++UlESyDvSMEEIKcCZzX6zLvXDiMo0pFZn5hWfhxfS2aF3sCAkUvDwmA1ZUVyS9qNawnEn0aKvQhkxF9WCqBPUIgBSYISnd3QmCZJs6qVekaYZqbmzGCfoGnp2AEnyAdjUpeajTwJh4XfU778S6d7tNQISlA3rFN9AkqzaYQmLOzuKIxuGuYaE4H++F/RvbqVEVXE+cgsbSEFFH0Hh+RtW2sxmLo9npYoy/yNpUajkBeo9ftzkwSVFstIeBVpjH8rhc0xigBe43f9/dmKBTCburv4ISb//VvsYe9mmXbX/VIZHman8ntdH7y0BbFSwrjmX6H4s8/AQYAQChL+KIinhAAAAAASUVORK5CYII=") no-repeat left bottom


### PR DESCRIPTION
Automatically generated queries start with the primary_key field
which is linked to edit a row. The haeckel theme changes this link
into an edit icon, and there's no problem since adminer will
automatically select the primary_key a second time.

In custom SQL queries however this second field selection can't be
inserted and the primary_key is eaten by the icon, making it hard
to find a row by id.
