### PR TITLE
Make "select" as primary link

### DIFF
--- a/adminer/db.inc.php
+++ b/adminer/db.inc.php
@@ -80,7 +80,7 @@ if ($adminer->homepage()) {
 			foreach ($tables_list as $name => $type) {
 				$view = ($type !== null && !preg_match('~table~i', $type));
 				echo '<tr' . odd() . '><td>' . checkbox(($view ? "views[]" : "tables[]"), $name, in_array($name, $tables_views, true), "", "formUncheck('check-all');");
-				echo '<th>' . (support("table") || support("indexes") ? '<a href="' . h(ME) . 'table=' . urlencode($name) . '" title="' . lang('Show structure') . '">' . h($name) . '</a>' : h($name));
+				echo '<th>' . (support("table") || support("indexes") ? '<a href="' . h(ME) . 'select=' . urlencode($name) . '" title="' . lang('Show structure') . '">' . h($name) . '</a>' : h($name));
 				if ($view) {
 					echo '<td colspan="6"><a href="' . h(ME) . "view=" . urlencode($name) . '" title="' . lang('Alter view') . '">' . lang('View') . '</a>';
 					echo '<td align="right"><a href="' . h(ME) . "select=" . urlencode($name) . '" title="' . lang('Select data') . '">?</a>';

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -883,10 +883,10 @@ bodyLoad('<?php echo (is_object($connection) ? substr($connection->server_info, 
 	function tablesPrint($tables) {
 		echo "<p id='tables' onmouseover='menuOver(this, event);' onmouseout='menuOut(this);'>\n";
 		foreach ($tables as $table => $status) {
-			echo '<a href="' . h(ME) . 'select=' . urlencode($table) . '"' . bold($_GET["select"] == $table || $_GET["edit"] == $table, "select") . ">" . lang('select') . "</a> ";
+			echo '<a href="' . h(ME) . 'edit=' . urlencode($table) . '"' . bold($_GET["select"] == $table || $_GET["edit"] == $table, "edit") . ">" . lang('edit') . "</a> ";
 			$name = $this->tableName($status);
 			echo (support("table") || support("indexes")
-				? '<a href="' . h(ME) . 'table=' . urlencode($table) . '"'
+				? '<a href="' . h(ME) . 'select=' . urlencode($table) . '"'
 					. bold(in_array($table, array($_GET["table"], $_GET["create"], $_GET["indexes"], $_GET["foreign"], $_GET["trigger"])), (is_view($status) ? "view" : ""), "structure")
 					. " title='" . lang('Show structure') . "'>$name</a>"
 				: "<span>$name</span>"


### PR DESCRIPTION
The main purpose of a DB management system (like phpMyadmin adn Adminer) is to view and edit data. We make the DB structure only once, then you select table more often.

The original Adminer designed in a way that when clicking on the table name, it will show "alter table". Which I really really hate because I don't alter table that often, I want to select it.

So I did 2 simple things in this commit:
1. On the left menu: Change the "select" link => "edit" link
2. Change all links of table names from **alter** table => **select** table

![image](https://cloud.githubusercontent.com/assets/7647566/4110461/804bec38-31f2-11e4-9dee-edee5218a601.png)

Hopefully the owner of this repo will merge it so that everyone else will benefit from this convenience. Thanks,

Binh
