### PR TITLE
Scrolls the currently selected table into view on the left hand side

### DIFF
--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -131,6 +131,9 @@ function page_footer($missing = "") {
 <div id="menu">
 <?php $adminer->navigation($missing); ?>
 </div>
-<script type="text/javascript">setupSubmitHighlight(document);</script>
+<script type="text/javascript">
+    setupSubmitHighlight(document);
+    scrollToActiveTable();
+</script>
 <?php
 }

--- a/adminer/static/functions.js
+++ b/adminer/static/functions.js
@@ -793,3 +793,33 @@ function cloneNode(el) {
 	setupSubmitHighlight(el2);
 	return el2;
 }
+
+/* Find the absolute position of an element on the page (http://www.quirksmode.org/js/findpos.html)
+ */
+function findPos(el) {
+    var curleft = 0, curtop = 0;
+    if(el.offsetParent) {
+        curleft = el.offsetLeft
+        curtop = el.offsetTop
+        while(el = el.offsetParent) {
+            curleft += el.offsetLeft
+            curtop += el.offsetTop
+        }
+    }
+    return [curleft, curtop];
+}
+
+/** Put the active table menu item in view on page load, if the tables list is scrollable
+ */
+function scrollToActiveTable() {
+    var elTables = document.getElementById('tables');
+    var isScrollable = elTables.scrollHeight > elTables.clientHeight;
+    if (isScrollable && document.getElementsByClassName) { // test for getElementsByClassName...it's not available in IE8 and below
+        var active = elTables.getElementsByClassName('active')[0];
+        if (active) {
+            elTables.scrollTop = findPos(active)[1] - findPos(elTables)[1] - active.offsetHeight * 3; // scroll the active table to the top of the list, with a few tables above it shown for convenient access
+        }
+    }
+}
+
+


### PR DESCRIPTION
For adminer.css themes which set #tables to overflow:auto, this will
keep the currently chosen table in the menu scrolled into view on each
page load
