### PR TITLE
Add an optional display limit for SQL command

### DIFF
--- a/adminer/include/editing.inc.php
+++ b/adminer/include/editing.inc.php
@@ -5,7 +5,7 @@
 * @param array
 * @return array $orgtables
 */
-function select($result, $connection2 = null, $orgtables = array()) {
+function select($result, $connection2 = null, $orgtables = array(), $limit = null) {
 	global $jush;
 	$links = array(); // colno => orgtable - create links from these columns
 	$indexes = array(); // orgtable => array(column => colno) - primary keys
@@ -14,7 +14,7 @@ function select($result, $connection2 = null, $orgtables = array()) {
 	$types = array(); // colno => type - display char in <code>
 	$return = array(); // table => orgtable - mapping to use in EXPLAIN
 	odd(''); // reset odd for each result
-	for ($i=0; $row = $result->fetch_row(); $i++) {
+	for ($i=0; ($row = $result->fetch_row()) && $limit-- !== 0; $i++) {
 		if (!$i) {
 			echo "<table cellspacing='0' class='nowrap'>\n";
 			echo "<thead><tr>";

--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -16,6 +16,14 @@ if (!$error && $_POST["clear"]) {
 
 page_header((isset($_GET["import"]) ? lang('Import') : lang('SQL command')), $error);
 
+$displayLimit = null;
+if (isset($_POST['display-limit'])) {
+	$displayLimit = (int) $_POST['display-limit'];
+}
+if ($displayLimit < 1) {
+	$displayLimit = null;
+}
+
 if (!$error && $_POST) {
 	$fp = false;
 	if (!isset($_GET["import"])) {
@@ -121,7 +129,7 @@ if (!$error && $_POST) {
 								}
 
 							} elseif (is_object($result)) {
-								$orgtables = select($result, $connection2);
+								$orgtables = select($result, $connection2, array(), $displayLimit);
 								if (!$_POST["only_errors"]) {
 									echo "<form action='' method='post'>\n";
 									echo "<p>" . ($result->num_rows ? lang('%d row(s)', $result->num_rows) : "") . $time;
@@ -216,6 +224,9 @@ if (!isset($_GET["import"])) {
 
 echo checkbox("error_stops", 1, ($_POST ? $_POST["error_stops"] : isset($_GET["import"])), lang('Stop on error')) . "\n";
 echo checkbox("only_errors", 1, ($_POST ? $_POST["only_errors"] : isset($_GET["import"])), lang('Show only errors')) . "\n";
+
+echo "<label><input type=\"number\" name=\"display-limit\" min=\"1\" value=\"$displayLimit\">", lang("Display Limit"), "</label>";
+
 echo "<input type='hidden' name='token' value='$token'>\n";
 
 if (!isset($_GET["import"]) && $history) {


### PR DESCRIPTION
Hi, this is a proposition to solve the problem describe here : https://sourceforge.net/p/adminer/bugs-and-features/406/

This PR add an optional "Display limit" in the SQL Command form. When executing queries with more rows than the "Display limit", the output will be truncated. This makes it possible to export large result sets without having to display it all in the browser.

Please tell me if this solution is good for you or if you have any suggestion
