### PR TITLE
Fix MS SQL Driver to not show warnings for version fetching on connection and to retrieve the next set of results properly

### DIFF
--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -164,7 +164,7 @@ if (isset($_GET["mssql"])) {
 			}
 
 			function query($query, $unbuffered = false) {
-				$result = mssql_query($query, $this->_link); //! $unbuffered
+				$result = @mssql_query($query, $this->_link); //! $unbuffered
 				$this->error = "";
 				if (!$result) {
 					$this->error = mssql_get_last_message();
@@ -186,7 +186,7 @@ if (isset($_GET["mssql"])) {
 			}
 
 			function next_result() {
-				return mssql_next_result($this->_result);
+				return mssql_next_result($this->_result->_result);
 			}
 
 			function result($query, $field = 0) {


### PR DESCRIPTION
When trying to connect, the redirect didn't happen properly for me because the connect query caused warnings about an unset type.

Connect statement: https://github.com/wiseloren/adminer/blob/05743711db172c66bffc2c66f48f3cbe21a159ad/adminer/drivers/mssql.inc.php#L149

I resolved this by placing an @ before the mssql_query statement so the warnings are suppressed.
Secondly, the result is placed in the Min_result class so fetching the next result needs to be done with $this->_result->_result
