### PR TITLE
Fix tables list alphabetical order in PostgreSQL driver

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -231,9 +231,9 @@ if (isset($_GET["pgsql"])) {
 UNION ALL
 SELECT matviewname, 'MATERIALIZED VIEW'
 FROM pg_matviews
-WHERE schemaname = current_schema()
-ORDER BY table_name";
+WHERE schemaname = current_schema()";
 		}
+		$query .= "ORDER BY 1";
 		return get_key_vals($query);
 	}
 


### PR DESCRIPTION
Returns tables list to alphabetical order which was broken in vrana:7a370e7