### PR TITLE
added character set utf8 to connection

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -293,7 +293,7 @@ if (!defined("DRIVER")) {
 		$credentials = $adminer->credentials();
 		if ($connection->connect($credentials[0], $credentials[1], $credentials[2])) {
 			$connection->set_charset(charset($connection)); // available in MySQLi since PHP 5.0.5
-			$connection->query("SET sql_quote_show_create = 1, autocommit = 1");
+			$connection->query("SET sql_quote_show_create = 1, autocommit = 1, character set utf8");
 			return $connection;
 		}
 		$return = $connection->error;


### PR DESCRIPTION
I discovered a bug. When using adminer on a strato.de shared host mysql database, it is not displaying field values containing äöüß-characters. Had to add this to make it work. Strato.de databases are created as latin1_german1_ci. Changing to utf8_general_ci doesn't fix the issue. 
Here's a config dumb of strato.de mysql server and newly created database: https://gist.github.com/Konrad90/a4f593059459b14af2aa 
I haven't figured out which setting is causing the issue.