### PR TITLE
set_charset was not getting defined on mysqli

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -39,6 +39,10 @@ if (!defined("DRIVER")) {
 			function quote($string) {
 				return "'" . $this->escape_string($string) . "'";
 			}
+
+            		function set_charset($charset) {
+                		$this->query("SET NAMES $charset");
+            		}
 		}
 
 	} elseif (extension_loaded("mysql") && !(ini_get("sql.safe_mode") && extension_loaded("pdo_mysql"))) {


### PR DESCRIPTION
I discovered a bug. When using adminer on a strato.de shared host mysql database, it is not displaying field values containing äöüß-characters. Had to add this to make it work.