### PR TITLE
fix logger for SQL commands

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -197,6 +197,15 @@ focus(document.getElementById('username'));
 		;
 	}
 
+	/** Query printed in SQL command before execution
+	* @param string query to be executed
+	* @return string
+	*/
+	function sqlCommandQuery($query)
+	{
+		return shorten_utf8(trim($query), 1000);
+	}
+
 	/** Description of a row in a table
 	* @param string
 	* @return string SQL expression, empty string for no description

--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -93,7 +93,7 @@ if (!$error && $_POST) {
 						$empty = false;
 						$q = substr($query, 0, $pos);
 						$commands++;
-						$print = "<pre id='sql-$commands'><code class='jush-$jush'>" . shorten_utf8(trim($q), 1000) . "</code></pre>\n";
+						$print = "<pre id='sql-$commands'><code class='jush-$jush'>" . $adminer->sqlCommandQuery($q) . "</code></pre>\n";
 						if ($jush == "sqlite" && preg_match("~^$space*+ATTACH\\b~i", $q, $match)) {
 							// PHP doesn't support setting SQLITE_LIMIT_ATTACHED
 							echo $print;

--- a/plugins/plugin.php
+++ b/plugins/plugin.php
@@ -177,6 +177,11 @@ class AdminerPlugin extends Adminer {
 		return $this->_applyPlugin(__FUNCTION__, $args);
 	}
 
+	function sqlCommandQuery() {
+		$args = func_get_args();
+		return $this->_applyPlugin(__FUNCTION__, $args);
+	}
+
 	function rowDescription($table) {
 		$args = func_get_args();
 		return $this->_applyPlugin(__FUNCTION__, $args);

--- a/plugins/sql-log.php
+++ b/plugins/sql-log.php
@@ -18,6 +18,14 @@ class AdminerSqlLog {
 	}
 	
 	function messageQuery($query, $time) {
+		$this->_log($query);
+	}
+
+	function sqlCommandQuery($query) {
+		$this->_log($query);
+	}
+
+	function _log($query) {
 		if ($this->filename == "") {
 			$adminer = adminer();
 			$this->filename = $adminer->database() . ".sql"; // no database goes to ".sql" to avoid collisions


### PR DESCRIPTION
Queries from SQL commands were not logged by sql-logs plugin

This PR add a pluggable sqlCommandQuery method to Adminer that is called by sql-logs (and could be used to customize query output)
