### PR TITLE
Remove redundant dumpTable

### DIFF
--- a/adminer/select.inc.php
+++ b/adminer/select.inc.php
@@ -76,7 +76,6 @@ if ($_POST && !$error) {
 	if ($_POST["export"]) {
 		cookie("adminer_import", "output=" . urlencode($_POST["output"]) . "&format=" . urlencode($_POST["format"]));
 		dump_headers($TABLE);
-		$adminer->dumpTable($TABLE, "");
 		if (!is_array($_POST["check"]) || $unselected === array()) {
 			$query = "SELECT $from$where_check$group_by";
 		} else {

--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -1,7 +1,6 @@
 <?php
 if (!$error && $_POST["export"]) {
 	dump_headers("sql");
-	$adminer->dumpTable("", "");
 	$adminer->dumpData("", "table", $_POST["query"]);
 	exit;
 }


### PR DESCRIPTION
Is this necessary here? When exporting specific rows from a table, the table schema / creation string is never actually dumped with it - since the style is always empty string, the only thing it may potentially output is a `SET NAMES UTF8MB4`. 

Removing this would allow the export function to work on drivers (like MSSQL) that don't have a `create_sql()` function implemented.
