### PR TITLE
Export table feature: Allow exporting of one query for each row

### DIFF
--- a/adminer/dump.inc.php
+++ b/adminer/dump.inc.php
@@ -157,7 +157,8 @@ echo "<tr><th>" . lang('Tables') . "<td>" . html_select('table_style', $table_st
 	. (support("trigger") ? checkbox("triggers", 1, $row["triggers"], lang('Triggers')) : "")
 ;
 
-echo "<tr><th>" . lang('Data') . "<td>" . html_select('data_style', $data_style, $row["data_style"]);
+echo "<tr><th>" . lang('Data') . "<td>" . html_select('data_style', $data_style, $row["data_style"])
+	. checkbox("single_row_insert", 1, $row["single_row_insert"], lang('One query for each row'));
 ?>
 </table>
 <p><input type="submit" value="<?php echo lang('Export'); ?>">

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -671,6 +671,10 @@ focus(document.getElementById('username'));
 	function dumpData($table, $style, $query) {
 		global $connection, $jush;
 		$max_packet = ($jush == "sqlite" ? 0 : 1048576); // default, minimum is 1024
+		if ($_POST["single_row_insert"]) {
+			// single_row_insert checkbox checked, set $max_packet to 0 to force new query for each row
+			$max_packet = 0;
+		}
 		if ($style) {
 			if ($_POST["format"] == "sql") {
 				if ($style == "TRUNCATE+INSERT") {

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -671,7 +671,7 @@ focus(document.getElementById('username'));
 	function dumpData($table, $style, $query) {
 		global $connection, $jush;
 		$max_packet = ($jush == "sqlite" ? 0 : 1048576); // default, minimum is 1024
-		if ($_POST["single_row_insert"]) {
+		if (isset($_POST["single_row_insert"]) && $_POST["single_row_insert"]) {
 			// single_row_insert checkbox checked, set $max_packet to 0 to force new query for each row
 			$max_packet = 0;
 		}

--- a/adminer/lang/nl.inc.php
+++ b/adminer/lang/nl.inc.php
@@ -151,6 +151,7 @@ $translations = array(
 	'open' => 'openen',
 	'save' => 'opslaan',
 	'Format' => 'Formaat',
+	'One query for each row' => 'Een query voor elke regel',
 	'Functions' => 'Functies',
 	'Aggregation' => 'Totalen',
 	'Event has been dropped.' => 'Event werd verwijderd.',

--- a/adminer/lang/xx.inc.php
+++ b/adminer/lang/xx.inc.php
@@ -79,6 +79,7 @@ $translations = array(
 	'Saving' => 'Xx',
 	'Format' => 'Xx',
 	'Data' => 'Xx',
+	'One query for each row' => 'xx',
 	
 	'Database' => 'Xx',
 	'database' => 'xx',


### PR DESCRIPTION
In some cases I would like to export table data with one query for each row in the table. This is useful for when you compare exported data or manually pick queries (rows). This was something I missed after switching from phpMyAdmin
- the dumpData function now checks for 'single_row_insert' param in $_POST
- added a checkbox in export interface
- added new language key 'One query for each row' and added it to nl (and xx) language
