### PR TITLE
PHP 7 compatibility fixes

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -81,7 +81,7 @@ if (isset($_GET["elastic"])) {
 		class Min_Result {
 			var $num_rows, $_rows;
 
-			function Min_Result($rows) {
+			function __construct($rows) {
 				$this->num_rows = count($this->_rows);
 				$this->_rows = $rows;
 				reset($this->_rows);

--- a/adminer/drivers/firebird.inc.php
+++ b/adminer/drivers/firebird.inc.php
@@ -4,7 +4,7 @@
 */
 
 $drivers['firebird'] = 'Firebird (alpha)';
-	
+
 if (isset($_GET["firebird"])) {
 	$possible_drivers = array("interbase");
 	define("DRIVER", "firebird");
@@ -21,7 +21,7 @@ if (isset($_GET["firebird"])) {
 			;
 
 			function connect($server, $username, $password) {
-				$this->_link = ibase_connect($server, $username, $password); 
+				$this->_link = ibase_connect($server, $username, $password);
 				if ($this->_link) {
 					$url_parts = explode(':', $server);
 					$this->service_link = ibase_service_attach($url_parts[0], $username, $password);
@@ -81,7 +81,7 @@ if (isset($_GET["firebird"])) {
 		class Min_Result {
 			var $num_rows, $_result, $_offset = 0;
 
-			function Min_Result($result) {
+			function __construct($result) {
 				$this->_result = $result;
 				// $this->num_rows = ibase_num_rows($result);
 			}
@@ -110,9 +110,9 @@ if (isset($_GET["firebird"])) {
 		}
 
 	}
-	
-	
-	
+
+
+
 	class Min_Driver extends Min_SQL {
 	}
 
@@ -141,7 +141,7 @@ if (isset($_GET["firebird"])) {
 	}
 
 	function limit($query, $where, $limit, $offset = 0, $separator = " ") {
-		$return = ''; 
+		$return = '';
 		$return .= ($limit !== null ? $separator . "FIRST $limit" . ($offset ? " SKIP $offset" : "") : "");
 		$return .= " $query$where";
 		return $return;
@@ -172,7 +172,7 @@ if (isset($_GET["firebird"])) {
 		while ($row = ibase_fetch_assoc($result)) {
 				$return[$row['RDB$RELATION_NAME']] = 'table';
 		}
-		ksort($return);	
+		ksort($return);
 		return $return;
 	}
 

--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -28,7 +28,7 @@ if (isset($_GET["mongo"])) {
 					return false;
 				}
 			}
-			
+
 			function query($query) {
 				return false;
 			}
@@ -52,7 +52,7 @@ if (isset($_GET["mongo"])) {
 		class Min_Result {
 			var $num_rows, $_rows = array(), $_offset = 0, $_charset = array();
 
-			function Min_Result($result) {
+			function __construct($result) {
 				foreach ($result as $item) {
 					$row = array();
 					foreach ($item as $key => $val) {
@@ -115,7 +115,7 @@ if (isset($_GET["mongo"])) {
 
 	class Min_Driver extends Min_SQL {
 		public $primary = "_id";
-		
+
 		function select($table, $select, $where, $group, $order = array(), $limit = 1, $page = 0, $print = false) {
 			$select = ($select == array("*")
 				? array()
@@ -133,7 +133,7 @@ if (isset($_GET["mongo"])) {
 				->skip($page * $limit)
 			);
 		}
-		
+
 		function insert($table, $set) {
 			try {
 				$return = $this->_conn->_db->selectCollection($table)->insert($set);
@@ -331,7 +331,7 @@ if (isset($_GET["mongo"])) {
 		}
 		return true;
 	}
-	
+
 	function last_id() {
 		global $connection;
 		return $connection->last_id;

--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -93,7 +93,7 @@ if (isset($_GET["mssql"])) {
 		class Min_Result {
 			var $_result, $_offset = 0, $_fields, $num_rows;
 
-			function Min_Result($result) {
+			function __construct($result) {
 				$this->_result = $result;
 				// $this->num_rows = sqlsrv_num_rows($result); // available only in scrollable results
 			}
@@ -201,7 +201,7 @@ if (isset($_GET["mssql"])) {
 		class Min_Result {
 			var $_result, $_offset = 0, $_fields, $num_rows;
 
-			function Min_Result($result) {
+			function __construct($result) {
 				$this->_result = $result;
 				$this->num_rows = mssql_num_rows($result);
 			}

--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -9,7 +9,7 @@ if (!defined("DRIVER")) {
 		class Min_DB extends MySQLi {
 			var $extension = "MySQLi";
 
-			function Min_DB() {
+			function __construct() {
 				parent::init();
 			}
 
@@ -44,7 +44,7 @@ if (!defined("DRIVER")) {
 				$row = $result->fetch_array();
 				return $row[$field];
 			}
-			
+
 			function quote($string) {
 				return "'" . $this->escape_string($string) . "'";
 			}
@@ -181,7 +181,7 @@ if (!defined("DRIVER")) {
 			/** Constructor
 			* @param resource
 			*/
-			function Min_Result($result) {
+			function __construct($result) {
 				$this->_result = $result;
 				$this->num_rows = mysql_num_rows($result);
 			}

--- a/adminer/drivers/oracle.inc.php
+++ b/adminer/drivers/oracle.inc.php
@@ -80,7 +80,7 @@ if (isset($_GET["oracle"])) {
 		class Min_Result {
 			var $_result, $_offset = 1, $num_rows;
 
-			function Min_Result($result) {
+			function __construct($result) {
 				$this->_result = $result;
 			}
 

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -94,7 +94,7 @@ if (isset($_GET["pgsql"])) {
 		class Min_Result {
 			var $_result, $_offset = 0, $num_rows;
 
-			function Min_Result($result) {
+			function __construct($result) {
 				$this->_result = $result;
 				$this->num_rows = pg_num_rows($result);
 			}

--- a/adminer/drivers/simpledb.inc.php
+++ b/adminer/drivers/simpledb.inc.php
@@ -56,7 +56,7 @@ if (isset($_GET["simpledb"])) {
 		class Min_Result {
 			var $num_rows, $_rows = array(), $_offset = 0;
 
-			function Min_Result($result) {
+			function __construct($result) {
 				foreach ($result as $item) {
 					$row = array();
 					if ($item->Name != '') { // SELECT COUNT(*)

--- a/adminer/drivers/sqlite.inc.php
+++ b/adminer/drivers/sqlite.inc.php
@@ -11,7 +11,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 			class Min_SQLite {
 				var $extension = "SQLite3", $server_info, $affected_rows, $errno, $error, $_link;
 
-				function Min_SQLite($filename) {
+				function __construct($filename) {
 					$this->_link = new SQLite3($filename);
 					$version = $this->_link->version();
 					$this->server_info = $version["versionString"];
@@ -55,7 +55,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 			class Min_Result {
 				var $_result, $_offset = 0, $num_rows;
 
-				function Min_Result($result) {
+				function __construct($result) {
 					$this->_result = $result;
 				}
 
@@ -87,7 +87,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 			class Min_SQLite {
 				var $extension = "SQLite", $server_info, $affected_rows, $error, $_link;
 
-				function Min_SQLite($filename) {
+				function __construct($filename) {
 					$this->server_info = sqlite_libversion();
 					$this->_link = new SQLiteDatabase($filename);
 				}
@@ -127,7 +127,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 			class Min_Result {
 				var $_result, $_offset = 0, $num_rows;
 
-				function Min_Result($result) {
+				function __construct($result) {
 					$this->_result = $result;
 					if (method_exists($result, 'numRows')) { // not available in unbuffered query
 						$this->num_rows = $result->numRows();
@@ -172,7 +172,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 		class Min_SQLite extends Min_PDO {
 			var $extension = "PDO_SQLite";
 
-			function Min_SQLite($filename) {
+			function __construct($filename) {
 				$this->dsn(DRIVER . ":$filename", "", "");
 			}
 		}
@@ -182,7 +182,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 	if (class_exists("Min_SQLite")) {
 		class Min_DB extends Min_SQLite {
 
-			function Min_DB() {
+			function __construct() {
 				$this->Min_SQLite(":memory:");
 			}
 

--- a/adminer/include/driver.inc.php
+++ b/adminer/include/driver.inc.php
@@ -2,14 +2,14 @@
 
 /*abstract*/ class Min_SQL {
 	var $_conn;
-	
+
 	/** Create object for performing database operations
 	* @param Min_DB
 	*/
-	function Min_SQL($connection) {
+	function __construct($connection) {
 		$this->_conn = $connection;
 	}
-	
+
 	/** Select data from table
 	* @param string
 	* @param array result of $adminer->selectColumnsProcess()[0]
@@ -41,7 +41,7 @@
 		}
 		return $return;
 	}
-	
+
 	/** Delete data from table
 	* @param string
 	* @param string " WHERE ..."
@@ -52,7 +52,7 @@
 		$query = "FROM " . table($table);
 		return queries("DELETE" . ($limit ? limit1($query, $queryWhere) : " $query$queryWhere"));
 	}
-	
+
 	/** Update data in table
 	* @param string
 	* @param array escaped columns in keys, quoted data in values
@@ -69,7 +69,7 @@
 		$query = table($table) . " SET$separator" . implode(",$separator", $values);
 		return queries("UPDATE" . ($limit ? limit1($query, $queryWhere) : " $query$queryWhere"));
 	}
-	
+
 	/** Insert data into table
 	* @param string
 	* @param array escaped columns in keys, quoted data in values
@@ -81,7 +81,7 @@
 			: " DEFAULT VALUES"
 		));
 	}
-	
+
 	/** Insert or update data in table
 	* @param string
 	* @param array
@@ -91,20 +91,20 @@
 	/*abstract*/ function insertUpdate($table, $rows, $primary) {
 		return false;
 	}
-	
+
 	/** Begin transaction
 	* @return bool
 	*/
 	function begin() {
 		return queries("BEGIN");
 	}
-	
+
 	function commit() {
 		return queries("COMMIT");
 	}
-	
+
 	function rollback() {
 		return queries("ROLLBACK");
 	}
-	
+
 }

--- a/adminer/include/tmpfile.inc.php
+++ b/adminer/include/tmpfile.inc.php
@@ -3,20 +3,20 @@
 class TmpFile {
 	var $handler;
 	var $size;
-	
-	function TmpFile() {
+
+	function __construct() {
 		$this->handler = tmpfile();
 	}
-	
+
 	function write($contents) {
 		$this->size += strlen($contents);
 		fwrite($this->handler, $contents);
 	}
-	
+
 	function send() {
 		fseek($this->handler, 0);
 		fpassthru($this->handler);
 		fclose($this->handler);
 	}
-	
+
 }


### PR DESCRIPTION
Hey Jakub,

i've renamed the methods `Min_Result()`, `Min_DB()`, `Min_SQL()`, `TmpFile()` to `__construct()`.
This stops Adminer from throwing the warning: "Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP."

Best, Jens