### PR TITLE
Breadcumb no longer blocks the logout button.

### DIFF
--- a/designs/pappu687/adminer.css
+++ b/designs/pappu687/adminer.css
@@ -205,7 +205,7 @@ tr.odd td {
 	top:0px;
 	left:300px;
 	background:#48A5BF;
-	z-index:2;
+	z-index:0;
 	width:100%;
 	color:#ecf0f1;
 	padding:10px;


### PR DESCRIPTION
Not sure why the top bar is blocking the logout button. This patch allows the user  to see and click the logout button.
