### PR TITLE
[mssql] Don't free statement

### DIFF
--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -135,7 +135,6 @@ if (isset($_GET["mssql"])) {
 			}
 
 			function __destruct() {
-				sqlsrv_free_stmt($this->_result);
 			}
 		}
 
@@ -230,7 +229,6 @@ if (isset($_GET["mssql"])) {
 			}
 
 			function __destruct() {
-				mssql_free_result($this->_result);
 			}
 		}
 


### PR DESCRIPTION
Freeing the statement here will cause the statement to destruct too early when `$result = $connection->store_result();` is called in `sql.inc.php` (previous `$result` being overwritten triggers the destructor, but they hold the same `_result`).
As a consequence it will cause errors and will not show more than one table.
