### PR TITLE
Do not set input type as numeric if field is an array

### DIFF
--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -911,7 +911,7 @@ function input($field, $value, $function) {
 			}
 			// type='date' and type='time' display localized value which may be confusing, type='datetime' uses 'T' as date and time separator
 			echo "<input"
-				. ((!$has_function || $function === "") && preg_match('~(?<!o)int~', $field["type"]) ? " type='number'" : "")
+				. ((!$has_function || $function === "") && preg_match('~(?<!o)int~', $field["type"]) && !preg_match('~\[\]~', $field["full_type"]) ? " type='number'" : "")
 				. " value='" . h($value) . "'" . ($maxlength ? " maxlength='$maxlength'" : "")
 				. (preg_match('~char|binary~', $field["type"]) && $maxlength > 20 ? " size='40'" : "")
 				. "$attrs>"


### PR DESCRIPTION
Hello,

Just a really small fix regarding an issue i stumbled accross:
input type should not be numeric if the field is an array as you would input something like {1,2,3}

Regards,
K0n24d
