### PR TITLE
Specify filename when saving SQL command

### DIFF
--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -1,6 +1,6 @@
 <?php
 if (!$error && $_POST["export"]) {
-	dump_headers("sql");
+	dump_headers(!empty($_POST['filename']) ? $_POST['filename'] : 'sql');
 	$adminer->dumpTable("", "");
 	$adminer->dumpData("", "table", $_POST["query"]);
 	exit;
@@ -130,7 +130,8 @@ if (!$error && $_POST) {
 									echo $time;
 									$id = "export-$commands";
 									$export = ", <a href='#$id' onclick=\"return !toggle('$id');\">" . lang('Export') . "</a><span id='$id' class='hidden'>: "
-										. html_select("output", $adminer->dumpOutput(), $adminer_export["output"]) . " "
+										. html_select("output", $adminer->dumpOutput(), $adminer_export["output"], "alterClass(document.getElementById('filename'), 'hidden', !(this.value=='file'||this.value=='gz'))") . " "
+										. "<input type='text' name='filename' id='filename' class='hidden'> "
 										. html_select("format", $dump_format, $adminer_export["format"])
 										. "<input type='hidden' name='query' value='" . h($q) . "'>"
 										. " <input type='submit' name='export' value='" . lang('Export') . "'><input type='hidden' name='token' value='$token'></span>\n"


### PR DESCRIPTION
When exporting an SQL command from Adminer, it saves the file as "sql.csv" or "sql.csv.gz". This can make it difficult to work with multiple exports, as they become "sql (1).csv", "sql (2).csv" and so on, making it difficult to work out what each one actually is.

This change conditionally shows a text field when the user selects 'save' or 'gzip' from export. The extension will be added by Adminer. If left blank, it uses the default 'sql'.

I haven't added this to the dump database and select table pages, as the default behaviour of using the database/table name is more appropriate in those situations.
