### PR TITLE
Allow passing in of config filename to login server plugin

### DIFF
--- a/plugins/login-servers.php
+++ b/plugins/login-servers.php
@@ -11,11 +11,19 @@ class AdminerLoginServers {
 	var $servers, $driver;
 	
 	/** Set supported servers
-	* @param array array($domain) or array($domain => $description) or array($category => array())
+	* @param array|string array($domain) or array($domain => $description) or array($category => array()) or path to file with server list
 	* @param string
 	*/
 	function __construct($servers, $driver = "server") {
-		$this->servers = $servers;
+		if (is_string($servers)) {
+			if (pathinfo($servers, 4) == "json") {
+				$this->servers = json_decode(file_get_contents($servers), true);
+			} else {
+				$this->servers = include($servers);
+			}
+		} else {
+			$this->servers = $servers;
+		}
 		$this->driver = $driver;
 	}
 	


### PR DESCRIPTION
This means you can avoid editing a PHP file (and even store the list of
servers completely away from adminer.php if desired). Avoiding editing a
PHP file is desirable, as it could necessitate clearing an opcode cache
for the change to take effect.
