### PR TITLE
Oracle driver fixes for a more general usage

### DIFF
--- a/adminer/drivers/oracle.inc.php
+++ b/adminer/drivers/oracle.inc.php
@@ -165,7 +165,7 @@ if (isset($_GET["oracle"])) {
 	}
 
 	function get_databases() {
-		return get_vals("SELECT tablespace_name FROM user_tablespaces");
+		return get_vals("SELECT distinct tablespace_name FROM all_tables where tablespace_name is not null");
 	}
 
 	function limit($query, $where, $limit, $offset = 0, $separator = " ") {
@@ -359,7 +359,7 @@ AND c_src.TABLE_NAME = " . q($table);
 	}
 
 	function schemas() {
-		return get_vals("SELECT DISTINCT owner FROM dba_segments WHERE owner IN (SELECT username FROM dba_users WHERE default_tablespace NOT IN ('SYSTEM','SYSAUX'))");
+		return get_vals("SELECT DISTINCT owner FROM all_tables where owner not IN ('SYSTEM','SYS')");
 	}
 
 	function get_schema() {


### PR DESCRIPTION
Within the get_databases() function users granted to SELECT data by then table owner were not able to see the table structure since they do not have an entry in the USER_TABLESPACES view. Using the ALL_TABLES view gives the possibility to every user granted.

Generally only DBAs can see the DBA_SEGMENTS view which was used in the driver schema() function.
Using an easy filter in the ALL_TABLES view all "normal" users can obtain the full schema list.
