### PR TITLE
Consistently use same path to static files

### DIFF
--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -25,7 +25,7 @@ function page_header($title, $error = "", $breadcrumb = array(), $title2 = "") {
 <title><?php echo $title_page; ?></title>
 <link rel="stylesheet" type="text/css" href="../adminer/static/default.css">
 <script type="text/javascript" src="../adminer/static/functions.js"></script>
-<script type="text/javascript" src="static/editing.js"></script>
+<script type="text/javascript" src="../adminer/static/editing.js"></script>
 <?php if ($adminer->head()) { ?>
 <link rel="shortcut icon" type="image/x-icon" href="../adminer/static/favicon.ico">
 <link rel="apple-touch-icon" href="../adminer/static/favicon.ico">


### PR DESCRIPTION
For some reason, when running adminer from source, I always get a 404 on `/static/editing.js`. If I alter this line, the issue is resolved.