### PR TITLE
Tabs must also be escaped in JSON strings

### DIFF
--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -237,7 +237,7 @@ function json_row($key, $val = null) {
 		echo "{";
 	}
 	if ($key != "") {
-		echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\"\\/") . '"' : 'undefined');
+		echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\t\"\\/") . '"' : 'undefined');
 		$first = false;
 	} else {
 		echo "\n}\n";


### PR DESCRIPTION
If database table data contains tab characters (0x09) then those
must also be escaped along with newlines and carriage returns for
the resulting JSON file to be valid.