### PR TITLE
Output numeric values as int/float instead of strings in JSON export

### DIFF
--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -237,7 +237,11 @@ function json_row($key, $val = null) {
 		echo "{";
 	}
 	if ($key != "") {
-		echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\t\"\\/") . '"' : 'undefined');
+		if (is_numeric($val)) {
+			echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . $val;
+		} else {
+			echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\t\"\\/") . '"' : 'undefined');
+		}
 		$first = false;
 	} else {
 		echo "\n}\n";

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -237,7 +237,7 @@ function json_row($key, $val = null) {
 		echo "{";
 	}
 	if ($key != "") {
-		echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\"\\/") . '"' : 'undefined');
+		echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\t\"\\/") . '"' : 'undefined');
 		$first = false;
 	} else {
 		echo "\n}\n";


### PR DESCRIPTION
When exporting database into JSON format, export int/float values as numeric values instead of strings. Strings work as well of course but exporting integers and floats as numeric values makes more sense and is more "correct".