### PR TITLE
JSON export formatting improvements for tabs and numeric values

### DIFF
--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -237,7 +237,11 @@ function json_row($key, $val = null) {
 		echo "{";
 	}
 	if ($key != "") {
-		echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\t\"\\/") . '"' : 'undefined');
+		if (is_numeric($val)) {
+			echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . $val;
+		} else {
+			echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\t\"\\/") . '"' : 'undefined');
+		}
 		$first = false;
 	} else {
 		echo "\n}\n";

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -237,7 +237,7 @@ function json_row($key, $val = null) {
 		echo "{";
 	}
 	if ($key != "") {
-		echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\"\\/") . '"' : 'undefined');
+		echo ($first ? "" : ",") . "\n\t\"" . addcslashes($key, "\r\n\"\\/") . '": ' . ($val !== null ? '"' . addcslashes($val, "\r\n\t\"\\/") . '"' : 'undefined');
 		$first = false;
 	} else {
 		echo "\n}\n";


### PR DESCRIPTION
Suggesting changes to `json_row` function in `adminer/include/functions.inc.php` for
1. Handling tab characters in database table values by converting them to \t so that  resulting JSON data validates and
2. Exporting integers and floats as numeric values instead of strings
