### PR TITLE
foreign key link fix - added missing ns

### DIFF
--- a/adminer/select.inc.php
+++ b/adminer/select.inc.php
@@ -387,6 +387,13 @@ if (!$columns && support("table")) {
 										$link .= where_link($i, $foreign_key["target"][$i], $rows[$n][$source]);
 									}
 									$link = ($foreign_key["db"] != "" ? preg_replace('~([?&]db=)[^&]+~', '\\1' . urlencode($foreign_key["db"]), ME) : ME) . 'select=' . urlencode($foreign_key["table"]) . $link; // InnoDB supports non-UNIQUE keys
+									if (isset($foreign_key["ns"]) && $foreign_key["ns"]) {
+										if (preg_match('~([?&]ns=)[^&]+~', $link)) {
+											$link = preg_replace('~([?&]ns=)[^&]+~', '\\1' . urlencode($foreign_key["ns"]), $link);
+										} else {
+											$link .= "&ns=" . urlencode($foreign_key["ns"]);
+										}
+									}
 									if (count($foreign_key["source"]) == 1) {
 										break;
 									}


### PR DESCRIPTION
When I have foreign key defined across schemes (namespaces) in PostgreSQL, links on values in SELECT are invalid - keeps ns in URL unchanged.

This fix ensure the ns in link is correct - by foreign key target.
