### PR TITLE
postgresql error with index on hidden columns (ctid)

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -352,8 +352,9 @@ focus(document.getElementById('username'));
 		echo "var indexColumns = ";
 		$columns = array();
 		foreach ($indexes as $index) {
-			if ($index["type"] != "FULLTEXT") {
-				$columns[reset($index["columns"])] = 1;
+			$current_key = reset($index["columns"]);
+			if ($index["type"] != "FULLTEXT" && $current_key) {
+				$columns[$current_key] = 1;
 			}
 		}
 		$columns[""] = 1;


### PR DESCRIPTION
context:
On postgesql, if you have indexed hidden columns like ctid, there is some JS error on the json generation.

in order to test, add index : 

``` sql
create index on "SomeTable" (ctid);
```
