### PR TITLE
Fixed mssql driver for usage with microsoft's php7 sqlsrv extension

### DIFF
--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -109,11 +109,11 @@ if (isset($_GET["mssql"])) {
 			}
 
 			function fetch_assoc() {
-				return $this->_convert(sqlsrv_fetch_array($this->_result, SQLSRV_FETCH_ASSOC, SQLSRV_SCROLL_NEXT));
+				return $this->_convert(sqlsrv_fetch_array($this->_result, SQLSRV_FETCH_ASSOC));
 			}
 
 			function fetch_row() {
-				return $this->_convert(sqlsrv_fetch_array($this->_result, SQLSRV_FETCH_NUMERIC, SQLSRV_SCROLL_NEXT));
+				return $this->_convert(sqlsrv_fetch_array($this->_result, SQLSRV_FETCH_NUMERIC));
 			}
 
 			function fetch_field() {
@@ -288,7 +288,7 @@ if (isset($_GET["mssql"])) {
 	}
 
 	function get_databases() {
-		return get_vals("EXEC sp_databases");
+		return get_vals("SELECT name FROM sys.databases WHERE name NOT IN ('master', 'tempdb', 'model', 'msdb')");
 	}
 
 	function limit($query, $where, $limit, $offset = 0, $separator = " ") {


### PR DESCRIPTION
I recently upgraded to PHP 7  on my Linux server and the mssql driver stopped working in adminer while it was still working fine in one of my applications.

Digging into it I found 2 issues:

1. "EXEC sp_databases" didn't work anymore and has been deprecated for a while.
2. For some reason, using SQLSRV_SCROLL_NEXT didn't fetch anything from the result of any query. It seems to me that it was not really needed anyway and simply removing it was enough to make it work again.

PS: I am using this driver from microsoft: https://github.com/Microsoft/msphpsql/tree/PHP-7.0-Linux