### PR TITLE
postgresql : ERROR:  function connection_id() does not exist

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -1019,6 +1019,11 @@ if (!defined("DRIVER")) {
 		return queries("KILL " . number($val));
 	}
 
+	//needed kill support
+	function connection_id(){
+		return "SELECT CONNECTION_ID()";
+	}
+
 	function max_connections() {
 		global $connection;
 		return $connection->result("SELECT @@max_connections");

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -638,6 +638,11 @@ AND typelem = 0"
 		return queries("SELECT pg_terminate_backend(" . number($val).")");
 	}
 
+	//needed kill support
+	function connection_id(){
+		return "SELECT  pg_backend_pid()";
+	}
+
 	function max_connections() {
 		global $connection;
 		return $connection->result("SHOW max_connections");

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -1209,7 +1209,7 @@ function slow_query($query) {
 	$db = $adminer->database();
 	$timeout = $adminer->queryTimeout();
 	if (support("kill") && is_object($connection2 = connect()) && ($db == "" || $connection2->select_db($db))) {
-		$kill = $connection2->result("SELECT CONNECTION_ID()"); // MySQL and MySQLi can use thread_id but it's not in PDO_MySQL
+		$kill = $connection2->result(connection_id()); // MySQL and MySQLi can use thread_id but it's not in PDO_MySQL
 		?>
 <script type="text/javascript">
 var timeout = setTimeout(function () {


### PR DESCRIPTION
This pull request resolve the following error on postgresql database : 


ERROR:  function connection_id() does not exist at character 8
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
STATEMENT:  SELECT CONNECTION_ID()


Cause : specific mysql code to kill slow queries.

