### PR TITLE
postgresql : unique partial index musn't be considered as unique.

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -311,9 +311,9 @@ ORDER BY a.attnum"
 		$return = array();
 		$table_oid = $connection2->result("SELECT oid FROM pg_class WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = current_schema()) AND relname = " . q($table));
 		$columns = get_key_vals("SELECT attnum, attname FROM pg_attribute WHERE attrelid = $table_oid AND attnum > 0", $connection2);
-		foreach (get_rows("SELECT relname, indisunique::int, indisprimary::int, indkey, indoption FROM pg_index i, pg_class ci WHERE i.indrelid = $table_oid AND ci.oid = i.indexrelid", $connection2) as $row) {
+		foreach (get_rows("SELECT relname, indisunique::int, indisprimary::int, indkey, indoption , (indpred IS NOT NULL)::int as indispartial FROM pg_index i, pg_class ci WHERE i.indrelid = $table_oid AND ci.oid = i.indexrelid", $connection2) as $row) {
 			$relname = $row["relname"];
-			$return[$relname]["type"] = ($row["indisprimary"] ? "PRIMARY" : ($row["indisunique"] ? "UNIQUE" : "INDEX"));
+			$return[$relname]["type"] = ($row['indispartial'] ?  'PARTIAL' : ($row["indisprimary"] ? "PRIMARY" : ($row["indisunique"] ? "UNIQUE" : "INDEX")));
 			$return[$relname]["columns"] = array();
 			foreach (explode(" ", $row["indkey"]) as $indkey) {
 				$return[$relname]["columns"][] = $columns[$indkey];


### PR DESCRIPTION
Partial unique index are considered as unique and cand can cause trouble on row edition : 
Example update multiples row at once when you want to update only one row.

I didn't concatenate partial with PRIMARY or UNIQUE because the function 'unique_array()' use one regular expression that isn't anchored with the begining nor the end of the string "$index['type']".

