### PR TITLE
Add basic support for MySQL replication

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -972,6 +972,14 @@ if (!defined("DRIVER")) {
 		return get_key_vals("SHOW STATUS");
 	}
 
+	/** Get replication status of master or slave
+	* @param string $type
+	* @return array ($name => $value)
+	*/
+	function replication_status($type) {
+		return get_rows("SHOW $type STATUS");
+	}
+
 	/** Convert field in select and edit
 	* @param array one element from fields()
 	* @return string

--- a/adminer/include/connect.inc.php
+++ b/adminer/include/connect.inc.php
@@ -17,6 +17,7 @@ function connect_error() {
 			'processlist' => lang('Process list'),
 			'variables' => lang('Variables'),
 			'status' => lang('Status'),
+			'replication' => lang('Replication'),
 		) as $key => $val) {
 			if (support($key)) {
 				echo "<a href='" . h(ME) . "$key='>$val</a>\n";
@@ -77,7 +78,7 @@ if (isset($_GET["import"])) {
 	$_GET["sql"] = $_GET["import"];
 }
 
-if (!(DB != "" ? $connection->select_db(DB) : isset($_GET["sql"]) || isset($_GET["dump"]) || isset($_GET["database"]) || isset($_GET["processlist"]) || isset($_GET["privileges"]) || isset($_GET["user"]) || isset($_GET["variables"]) || $_GET["script"] == "connect" || $_GET["script"] == "kill")) {
+if (!(DB != "" ? $connection->select_db(DB) : isset($_GET["sql"]) || isset($_GET["dump"]) || isset($_GET["database"]) || isset($_GET["processlist"]) || isset($_GET["privileges"]) || isset($_GET["user"]) || isset($_GET["replication"]) || isset($_GET["variables"]) || $_GET["script"] == "connect" || $_GET["script"] == "kill")) {
 	if (DB != "" || $_GET["refresh"]) {
 		restart_session();
 		set_session("dbs", null);

--- a/adminer/index.php
+++ b/adminer/index.php
@@ -65,6 +65,8 @@ if (isset($_GET["download"])) {
 	include "./user.inc.php";
 } elseif (isset($_GET["processlist"])) {
 	include "./processlist.inc.php";
+} elseif (isset($_GET["replication"])) {
+	include "./replication.inc.php";
 } elseif (isset($_GET["select"])) {
 	include "./select.inc.php";
 } elseif (isset($_GET["variables"])) {

--- a/adminer/lang/xx.inc.php
+++ b/adminer/lang/xx.inc.php
@@ -45,6 +45,10 @@ $translations = array(
 	'Variables' => 'Xx',
 	'Status' => 'Xx',
 	
+	'Replication' => 'Xx',
+	'Master status' => 'Xx',
+	'Slave status' => 'Xx',
+	
 	'SQL command' => 'Xx',
 	'%d query(s) executed OK.' => array('Xx.', 'Xx.'),
 	'Query executed OK, %d row(s) affected.' => array('Xx.', 'Xx.'),

--- a/adminer/replication.inc.php
+++ b/adminer/replication.inc.php
@@ -1,0 +1,26 @@
+<?php
+page_header(lang('Replication'));
+
+echo "<p><b>" . lang('Master status') . "</b>" . doc_link(array("sql" => "show-master-status.html")) . "\n";
+$master_replication_status = replication_status("MASTER");
+echo "<table cellspacing='0'>\n";
+foreach ($master_replication_status[0] as $key => $val) {
+	echo "<tr>";
+	echo "<th>" . h($key);
+	echo "<td>" . nbsp($val);
+}
+echo "</table>\n";
+
+$slave_replication_status = replication_status("SLAVE");
+if (!empty($slave_replication_status)) {
+	echo "<p><b>" . lang('Slave status') . "</b>" . doc_link(array("sql" => "show-slave-status.html")) . "\n";
+	foreach ($slave_replication_status as $slave) {
+		echo "<table cellspacing='0'>\n";
+		foreach ($slave as $key => $val) {
+			echo "<tr>";
+			echo "<th>" . h($key);
+			echo "<td>" . nbsp($val);
+		}
+		echo "</table>\n";
+	}
+}

--- a/adminer/replication.inc.php
+++ b/adminer/replication.inc.php
@@ -18,7 +18,7 @@ if (!empty($slave_replication_status)) {
 		echo "<table cellspacing='0'>\n";
 		foreach ($slave as $key => $val) {
 			echo "<tr>";
-			echo "<th>" . h($key);
+			echo "<th>" . h($key) . doc_link(array("sql" => "show-slave-status.html#slavestatus_" . strtolower($key)));
 			echo "<td>" . nbsp($val);
 		}
 		echo "</table>\n";

--- a/changes.txt
+++ b/changes.txt
@@ -5,6 +5,7 @@ Add Cache-Control: immutable to static files
 PostgreSQL: Export
 PostgreSQL: Don't treat partial indexes as unique
 MS SQL: Support pdo_dblib
+MySQL: Add dedicated view for replication status
 
 Adminer 4.2.5 (released 2016-06-01):
 Fix remote execution in SQLite query

--- a/compile.php
+++ b/compile.php
@@ -343,7 +343,7 @@ foreach (glob(dirname(__FILE__) . "/adminer/drivers/" . ($driver ? $driver : "*"
 
 include dirname(__FILE__) . "/adminer/include/pdo.inc.php";
 include dirname(__FILE__) . "/adminer/include/driver.inc.php";
-$features = array("call" => "routine", "dump", "event", "privileges", "procedure" => "routine", "processlist", "routine", "scheme", "sequence", "status", "trigger", "type", "user" => "privileges", "variables", "view");
+$features = array("call" => "routine", "dump", "event", "privileges", "procedure" => "routine", "processlist", "routine", "scheme", "sequence", "status", "trigger", "type", "user" => "privileges", "replication", "variables", "view");
 $lang_ids = array(); // global variable simplifies usage in a callback function
 $file = file_get_contents(dirname(__FILE__) . "/$project/index.php");
 if ($driver) {


### PR DESCRIPTION
This supersedes #157, and has all of the following improvements

- Documentation links added where appropriate
- Removed unused function
- Support multiple slaves
- Fixed indentation in parts
- Removed `<code>` tags from keys
- Updated changelog
- Made new strings translatable

The one thing I don't yet have is a screenshot. I'm still working on that!