### PR TITLE
Login screen: recognize mysql URLs

### DIFF
--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -62,6 +62,16 @@ if ($auth) {
 	$username = $auth["username"];
 	$password = (string) $auth["password"];
 	$db = $auth["db"];
+
+	// Recognize URLs like mysql://username:password@example.com/my_db?options
+    $split = preg_split("/[:\/@?]/", $server);
+    if (strpos($server, '://') > 0 && count($split) >= 7) {
+        $username = $split[3];
+        $password = $split[4];
+        $server = $split[5];
+        $db = $split[6];
+    }
+
 	set_password($vendor, $server, $username, $password);
 	$_SESSION["db"][$vendor][$server][$username][$db] = true;
 	if ($auth["permanent"]) {

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -64,8 +64,8 @@ if ($auth) {
 	$db = $auth["db"];
 
 	// Recognize URLs like mysql://username:password@example.com/my_db?options
-    $schemes = ['mssql', 'pdo_sqlsrv', 'mysql', 'mysql2', 'pdo_mysql', 'pgsql', 'postgres', 'postgresql', 'pdo_pgsql', 'pdo_oci', 'oci'];
-    $split = preg_split("/[:\/@?]/", $server);
+    $schemes = array('mssql', 'pdo_sqlsrv', 'mysql', 'mysql2', 'pdo_mysql', 'pgsql', 'postgres', 'postgresql', 'pdo_pgsql', 'pdo_oci', 'oci');
+    $split = preg_split('#[:/@?]#', $server);
     if (strpos($server, '://') > 0  &&  count($split) >= 7 && in_array($split[0], $schemes)) {
         $username = $split[3];
         $password = $split[4];

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -64,8 +64,9 @@ if ($auth) {
 	$db = $auth["db"];
 
 	// Recognize URLs like mysql://username:password@example.com/my_db?options
+    $schemes = ['mssql', 'pdo_sqlsrv', 'mysql', 'mysql2', 'pdo_mysql', 'pgsql', 'postgres', 'postgresql', 'pdo_pgsql', 'pdo_oci', 'oci'];
     $split = preg_split("/[:\/@?]/", $server);
-    if (strpos($server, '://') > 0 && count($split) >= 7) {
+    if (strpos($server, '://') > 0  &&  count($split) >= 7 && in_array($split[0], $schemes)) {
         $username = $split[3];
         $password = $split[4];
         $server = $split[5];


### PR DESCRIPTION
In the login screen, entering as server an URL like

  mysql://user:pass@example.com/my_db?options [1]

is a shorthand to setting 

- username=user, 
- password=pass,
- server=example.com, 
- database=my_db

[1] this syntax is used for example by doctrine