### PR TITLE
Fix PostgreSQL nullable fields in export

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -248,7 +248,7 @@ ORDER BY 1";
 FROM pg_class c
 JOIN pg_namespace n ON(n.nspname = current_schema() AND n.oid = c.relnamespace)
 WHERE relkind IN ('r', 'm', 'v')
-" . ($name != "" ? "AND relname = " . q($name) : "ORDER BY relname")
+" . ($name != "" ? "AND relname = " . q($name) : "ORDER BY c.oid")
 		) as $row) { //! Index_length, Auto_increment
 			$return[$row["Name"]] = $row;
 		}

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -638,7 +638,7 @@ AND typelem = 0"
 		foreach ($fields as $field_name => $field) {
 			$part = idf_escape($field['field']) . ' ' . $field['full_type']
 				. (is_null($field['default']) ? "" : " DEFAULT $field[default]")
-				. ($field['attnotnull'] ? "" : " NOT NULL");
+				. ($field['attnotnull'] ? " NOT NULL" : "");
 			$return_parts[] = $part;
 
 			// sequences for fields


### PR DESCRIPTION
When exporting the database schema, nullable fields show as non nullable and non nullables show as nullable. This commit fixes the issue.