### PR TITLE
Update for connecting to MS SQL

### DIFF
--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -239,7 +239,7 @@ if (isset($_GET["mssql"])) {
 			var $extension = "PDO_DBLIB";
 
 			function connect($server, $username, $password) {
-				$this->dsn("dblib:charset=utf8;host=" . str_replace(":", ";unix_socket=", preg_replace('~:(\\d)~', ';port=\\1', $server)), $username, $password);
+				$this->dsn("dblib:charset=utf8;host=" . $server), $username, $password);
 				return true;
 			}
 


### PR DESCRIPTION
When connecting using dblib driver, I get

> SQLSTATE[HY000] Unable to connect: Adaptive Server is unavailable or does not exist (severity 9)

After this change, no error to login.  But the table view shows:

```
Unicode data in a Unicode-only collation or ntext data cannot be sent to clients using DB-Library (such as ISQL) or ODBC version 3.7 or earlier. [4004] (severity 16) [SELECT c.*, t.name type, d.definition [default]
FROM sys.all_columns c
JOIN sys.all_objects o ON c.object_id = o.object_id
JOIN sys.types t ON c.user_type_id = t.user_type_id
LEFT JOIN sys.default_constraints d ON c.default_object_id = d.parent_column_id
WHERE o.schema_id = SCHEMA_ID('dbo') AND o.type IN ('S', 'U', 'V') AND o.name = 'eShop_Products2']
```