### PR TITLE
Skin: Chrome issue fix

### DIFF
--- a/designs/price/adminer.css
+++ b/designs/price/adminer.css
@@ -73,3 +73,4 @@ a:hover{color:#28c}
 a[title='Show structure'],#tables a[title='Show structure']{border:0;background:0;color:#369}
 .jush a{border:0;background:0;margin:0;padding:0}
 a.active,a.active:link,a.active:hover{text-decoration:underline}
+#tables li{clear: both;}


### PR DESCRIPTION
Hi Jakub, there is a fix of Chrome related issue - shifted icon for "select" and table name in left tables list. In Firefox it's fine.