### PR TITLE
Add text input to change filename

### DIFF
--- a/adminer/dump.inc.php
+++ b/adminer/dump.inc.php
@@ -7,9 +7,13 @@ if ($_POST && !$error) {
 		$cookie .= "&$key=" . urlencode($_POST[$key]);
 	}
 	cookie("adminer_export", substr($cookie, 1));
+    $filename = DB;
+    if ($_POST['output'] != 'text') {
+        $filename = preg_replace('/[^a-zA-Z0-9\-\._]/','', $_POST['filename']);
+    }
 	$tables = array_flip((array) $_POST["tables"]) + array_flip((array) $_POST["data"]);
 	$ext = dump_headers(
-		(count($tables) == 1 ? key($tables) : DB),
+		(count($tables) == 1 ? key($tables) : $filename),
 		(DB == "" || count($tables) > 1));
 	$is_sql = preg_match('~sql~', $_POST["format"]);
 
@@ -160,7 +164,9 @@ echo "<tr><th>" . lang('Tables') . "<td>" . html_select('table_style', $table_st
 echo "<tr><th>" . lang('Data') . "<td>" . html_select('data_style', $data_style, $row["data_style"]);
 ?>
 </table>
-<p><input type="submit" value="<?php echo lang('Export'); ?>">
+<p>
+<input type="text" name="filename" value="<?php echo $_GET['db']; ?>" placeholder="<?php echo lang('Filename'); ?>" title="<?php echo lang('Filename'); ?>">
+<input type="submit" value="<?php echo lang('Export'); ?>">
 <input type="hidden" name="token" value="<?php echo $token; ?>">
 
 <table cellspacing="0">

--- a/adminer/lang/cs.inc.php
+++ b/adminer/lang/cs.inc.php
@@ -336,4 +336,5 @@ $translations = array(
 	'Type has been dropped.' => 'Typ byl odstraněn.',
 	'Type has been created.' => 'Typ byl vytvořen.',
 	'Alter type' => 'Pozměnit typ',
+	'Filename' => 'Název souboru',
 );

--- a/adminer/lang/sk.inc.php
+++ b/adminer/lang/sk.inc.php
@@ -265,4 +265,5 @@ $translations = array(
 	'Permanent link' => 'Permanentný odkaz',
 	'Edit all' => 'Upraviť všetko',
 	'HH:MM:SS' => 'HH:MM:SS',
+	'Filename' => 'Názov súboru',
 );

--- a/changes.txt
+++ b/changes.txt
@@ -1,6 +1,7 @@
 Adminer 4.3.2-dev:
 MySQL: Remove dedicated view for replication status (added in 4.3.0)
 PostgreSQL: Sort table names (regression from 4.3.1)
+Editable dump filename when exporting
 
 Adminer 4.3.1 (released 2017-04-14):
 Fix permanent login after logout (bug #539)


### PR DESCRIPTION
On shared hostings the database names are autogenerated. It would be great to change dump filename when setting export options or be able to add some prefix/suffix.

![ss_2017-08-15-11-57-47](https://user-images.githubusercontent.com/454800/29311515-87b3355e-81b2-11e7-9c02-bca16e11b2e4.jpg)
