### PR TITLE
Change animated icons/links to static icons

### DIFF
--- a/designs/hever/adminer.css
+++ b/designs/hever/adminer.css
@@ -17,14 +17,9 @@ a[href*="&import="] {background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEU
 a[href$="&import="] {background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3gEJFDMETKEbQAAAAjZJREFUOMuVkjFoU2EUhc//3gsvptFCIdRHh2CrQ1AcmsUYHTKJDkJrFUdx6uJkpuLspCI4xaJLNik4SMGlOKgEdekQ0EEwFhJqCw+a16RJ//+/x0Heo6XN4B0v537nHLgKAKqNxXckSyTPPyu//IP/GFVtLL6f9INrKZXC791f3UvDysPP3tryjcHt7yTPkRQRaZL8KSKvRGRtbm7OxgCPZJ8kJtOnYaw99ZUfl8UQ5XK5kMlkQBI7OzuzURTNbmxs3Nne3v60srJyd2FhoQ0AztPLtflOv/22tdtCVo3hwvhFUATZbBaO48B1XUxMTCCfz6NUKmF6evqKtfZxnMABgOdXl+c7vTZ87wQUFcRyZOepqSmIyPWkAgA8+HCfFMG3rS8QEVCIvb09pFIpkES/30cYhmi325iZmYGI4BDgReW1Wl1d3apUKrler4coitBqtUASxhh0u10Mh0N4ngeSRwEAQBIk4bou0uk0PM+D53nQWsMYA/JfLRGBtfYoQEQSx/hIKQVrbbJzHGd0ghgQHxhj4LourLXQWkNrDdd1E81IQCy21iaAOEFcU2t9PEBEEvcYeDBZrNvf38ehPwAAay3CMEQul4Pv+4f/XSkEQYBisYhOpzMywb1Go/GmUCiM5fN5+L4PpRRIIggCRFGEZrOJ9fX1TWPMzQR+0Kler58RkUcicstxnPFMJgNjDMIwxGAw2DTG1K21T5aWlraOBRycWq120hhz1hgjWusf1Wp1eJzuL3uxkTGLHB98AAAAAElFTkSuQmCC") no-repeat scroll 2px bottom; padding-left:22px;}
 
 @media all and (min-device-width: 880px) {
-  #menu .links {height:22px; transition:.2s;}
-  #menu .links:hover {height:5em;}
-  #menu .links a {color:transparent; transition:.2s; display:block; margin-bottom:-1.25em;}
-  #menu .links > a + a {margin-left:22px;}
-  #menu .links > a + a + a {margin-left:44px;}
-  #menu .links > a + a + a + a {margin-left:66px;}
-  #menu .links:hover a {color:blue; margin:0;}
-  #menu .links a:hover {color:red;}
+  #menu .links {display: flex; padding: 0.4em 0em; text-align: center;}
+  #menu .links a {display: inline-block; flex: 1 1 auto; width: 24%; padding: 24px 4px 4px 4px; margin: 0; background-position: 50% 4px; font-size: 85%; white-space: normal;}
+  #menu .links > a + a {border-left: 1px solid #ccc;}
 }
 
 #tables li a[href*="&select="] {background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAHISURBVDjLpVPNK0RRFP+9D98syMwUspHkm9I0YkFZWBFKkZ0s7a3Ewh+ilChK7FgoZCJFKYlYKB8zk2+Z5t0P577He29kQU7dd+6575zf+d1zztWklPiPmOozt/U4SThjXIoyIQS4AJjSXO0lGGlvcXAm6Vzsz4xUhm0AIeX4QLig+C+ZpxbOG1wGhGYHr1zMUmZGWRgs0ha3PE1nX/8mWmdgWTzLB+DUYbhm9FfZ35IEyrhXA3VXJfPbsV8B9LQUIeUHYJ8ASobag1jcucNgW8g9W4reYSDi2YnnZDoDiwCokDANct6NwTB0LEdj0HRA/wxa2SN25JNBEdWluUhZ366gqmAaGvrCAXKOozccTGPgt8+vn8GYSGcgyTYp3dpBnBg42nbQPRBTo5bTvqYkmxL6AQhNTWQGBXY3B7BxlEBXozcW64dxRKoKUZBju+P06gl5WaaviMJBM3TNDlbypemIZgHYOnlwASsCmW7nHADGnBoQ3c76YmweJ9BR5zFYjsbRHwm4tmJg6PhWA7pCXXk+bu7fURHKweXtq/sWaksz7SC/CCGFrwtyZ3r+rCnFRZ7qr1qc6mLZj4f9OEyPL8lVpbX/PucPv5QPKHB1TdEAAAAASUVORK5CYII=") no-repeat scroll left bottom; clear:left; display:block; float:left; height:16px; margin-right:8px; padding-top:1px; overflow:hidden; padding-left:16px; width:0; text-decoration:none;}


### PR DESCRIPTION
The animated links SQL/import/export/create table are extremely annoying. This changes them to nice static buttons. Not too big, not too small.

![screenshot_20170824_013350](https://user-images.githubusercontent.com/16572/29643084-e3751568-886c-11e7-8e85-3ab84dc5e04c.png)