### PR TITLE
MySQL: Don't set time zone from PHP

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,7 +1,7 @@
 Adminer 4.3.2-dev:
-MySQL: Don't set time zone from PHP, fixes DST
 MySQL: Remove dedicated view for replication status (added in 4.3.0)
 PostgreSQL: Sort table names (regression from 4.3.1)
+Editor: Don't set time zone from PHP, fixes DST
 
 Adminer 4.3.1 (released 2017-04-14):
 Fix permanent login after logout (bug #539)

--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,5 @@
 Adminer 4.3.2-dev:
+MySQL: Don't set time zone from PHP, fixes DST
 MySQL: Remove dedicated view for replication status (added in 4.3.0)
 PostgreSQL: Sort table names (regression from 4.3.1)
 

--- a/editor/include/adminer.inc.php
+++ b/editor/include/adminer.inc.php
@@ -67,8 +67,6 @@ focus(document.getElementById('username'));
 	}
 
 	function login($login, $password) {
-		global $connection;
-		$connection->query("SET time_zone = " . q(substr_replace(@date("O"), ":", -2, 0))); // date("P") available since PHP 5.1.3, @ - requires date.timezone since PHP 5.3.0
 		return true;
 	}
 


### PR DESCRIPTION
Current implementation checks the delta between the local time and
UTC, and applies the delta as time zone for MySQL.

This assumption is wrong if the current time is DST enabled, but the
time that is converted isn't - and vice versa.

For example, Europe/Prague is "CET-1CEST,M3.5.0,M10.5.0/3", when
the MySQL connections is setup now (September, DST enabled) and
we are reading a TIMESTAMP from November, then MySQL applies +0200
instead of +0100 to that timestamp even though November is supposed
to be DST disabled.

There is no reliable and portable way in PHP to understand the
time zone, especially since PHP >= 5.4.0 ignores environment
variable and OS settings [1].

MySQL needs to be properly setup (TZ data loaded [2] and default
TZ set [3]), then everything will work just fine.

The current implementation however causes wrong data 50% of the
time, even when OS/MySQL/PHP is properly setup. As a MySQL
connection will converte timestamps from both DST enabled and
DST disabled dates, a static UTC offset must never be set at
connection level (set time_zone = ...).

This change removes the current implementation, therefor maintaining
OS/MySQL defaults, fixing the DST issue in properly configured
environments.

[1] http://php.net/manual/en/function.date-default-timezone-get.php
[2] https://dev.mysql.com/doc/refman/5.5/en/mysql-tzinfo-to-sql.html
[3] https://dev.mysql.com/doc/refman/5.5/en/time-zone-support.html