### PR TITLE
add schema search path for query as an extendable option

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -287,10 +287,12 @@ ORDER BY 1";
 	}
 
 	function table_status($name = "") {
+        global $connection;
+        $schema = !empty($_GET['ns']) ? "'" . pg_escape_string($connection->_link, $_GET['ns']) . "'" : 'current_schema()';
 		$return = array();
 		foreach (get_rows("SELECT c.relname AS \"Name\", CASE c.relkind WHEN 'r' THEN 'table' WHEN 'm' THEN 'materialized view' ELSE 'view' END AS \"Engine\", pg_relation_size(c.oid) AS \"Data_length\", pg_total_relation_size(c.oid) - pg_relation_size(c.oid) AS \"Index_length\", obj_description(c.oid, 'pg_class') AS \"Comment\", c.relhasoids::int AS \"Oid\", c.reltuples as \"Rows\", n.nspname
 FROM pg_class c
-JOIN pg_namespace n ON(n.nspname = current_schema() AND n.oid = c.relnamespace)
+JOIN pg_namespace n ON(n.nspname = $schema AND n.oid = c.relnamespace)
 WHERE relkind IN ('r', 'm', 'v')
 " . ($name != "" ? "AND relname = " . q($name) : "ORDER BY relname")
 		) as $row) { //! Index_length, Auto_increment

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -85,8 +85,6 @@ if (isset($_GET["pgsql"])) {
 			}
 
 			function result($query, $field = 0) {
-                $this->set_query_search_path();
-
 				$result = $this->query($query);
 				if (!$result || !$result->num_rows) {
 					return false;
@@ -288,11 +286,10 @@ ORDER BY 1";
 
 	function table_status($name = "") {
         global $connection;
-        $schema = !empty($_GET['ns']) ? "'" . pg_escape_string($connection->_link, $_GET['ns']) . "'" : 'current_schema()';
 		$return = array();
 		foreach (get_rows("SELECT c.relname AS \"Name\", CASE c.relkind WHEN 'r' THEN 'table' WHEN 'm' THEN 'materialized view' ELSE 'view' END AS \"Engine\", pg_relation_size(c.oid) AS \"Data_length\", pg_total_relation_size(c.oid) - pg_relation_size(c.oid) AS \"Index_length\", obj_description(c.oid, 'pg_class') AS \"Comment\", c.relhasoids::int AS \"Oid\", c.reltuples as \"Rows\", n.nspname
 FROM pg_class c
-JOIN pg_namespace n ON(n.nspname = $schema AND n.oid = c.relnamespace)
+JOIN pg_namespace n ON(n.nspname = current_schema() AND n.oid = c.relnamespace)
 WHERE relkind IN ('r', 'm', 'v')
 " . ($name != "" ? "AND relname = " . q($name) : "ORDER BY relname")
 		) as $row) { //! Index_length, Auto_increment

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -955,6 +955,18 @@ bodyLoad('<?php echo (is_object($connection) ? substr($connection->server_info, 
 		echo "</ul>\n";
 	}
 
+
+	/**
+	 * Set the schema search path before executing a query in PostgreSQL.
+	 * Return an array of schema names, -1 for all schemas, or an empty array to disable this feature.
+	 * 
+	 * @param $schemas
+	 * @return array
+	 */
+	function setPgSqlQuerySearchPath($schemas = array()) {
+		return $schemas;
+	}
+
 }
 
 $adminer = (function_exists('adminer_object') ? adminer_object() : new Adminer);

--- a/adminer/include/editing.inc.php
+++ b/adminer/include/editing.inc.php
@@ -130,6 +130,32 @@ function textarea($name, $value, $rows = 10, $cols = 80) {
 	echo "</textarea>";
 }
 
+
+/** Set the "Search Path" editable textbox values, if enabled
+ * @param array $schemas
+ * @return bool
+ */
+function input_for_query_search_path() {
+	global $connection;
+
+	$schemas = $connection->pgsql_query_search_path_override();
+
+	if (!empty($schemas)) {
+		echo "
+			<div style='display: block; margin: .8em 20px 0 0;'>
+				<p>
+					<label for='search_path'>Schema search path:</label>
+				</p>
+				<input style='width: 98%;' name='search_path' value='$schemas' />
+			</div>
+		";
+		return true;
+	}
+
+	return null;
+}
+
+
 /** Print table columns for type edit
 * @param string
 * @param array

--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -206,6 +206,7 @@ if (!isset($_GET["import"])) {
 	} elseif ($_GET["history"] != "") {
 		$q = $history[$_GET["history"]][0];
 	}
+	input_for_query_search_path();
 	echo "<p>";
 	textarea("query", $q, 20);
 	echo ($_POST ? "" : "<script type='text/javascript'>document.getElementsByTagName('textarea')[0].focus();</script>\n");


### PR DESCRIPTION
As posted here, https://sourceforge.net/p/adminer/discussion/960419/thread/e7a8672e/, adding multiple schemas to a search path (PostgreSQL) would allow shorter queries to be written in the SQL command textarea. Currently, only one search path can be utilized at a time. This new functionality allows comma separated schemas to be entered when writing a query, and is available by extending within the Adminer object.