### PR TITLE
Enforce sqlite foreign keys

### DIFF
--- a/adminer/drivers/sqlite.inc.php
+++ b/adminer/drivers/sqlite.inc.php
@@ -15,6 +15,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 					$this->_link = new SQLite3($filename);
 					$version = $this->_link->version();
 					$this->server_info = $version["versionString"];
+                    $this->_link->querySingle('PRAGMA foreign_keys = ON');
 				}
 
 				function query($query) {

--- a/adminer/drivers/sqlite.inc.php
+++ b/adminer/drivers/sqlite.inc.php
@@ -15,7 +15,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 					$this->_link = new SQLite3($filename);
 					$version = $this->_link->version();
 					$this->server_info = $version["versionString"];
-                    $this->_link->querySingle('PRAGMA foreign_keys = ON');
+					$this->_link->querySingle('PRAGMA foreign_keys = ON');
 				}
 
 				function query($query) {


### PR DESCRIPTION
Sqlite does not enforce foreign key constrains by default, it has to be done every time the database is open.
Note that the "PRAGMA foreign_keys = ON" must be executed in the constructor instead of the query() method. Otherwise it could conflict with a multi query call (import, SQL query) containing transactions or foreign keys off pragma such as a database creation script. This pragma must be executed outside of any transaction according the Sqlite doc.