### PR TITLE
Prevent display of null option for non null foreign keys

### DIFF
--- a/plugins/edit-foreign.php
+++ b/plugins/edit-foreign.php
@@ -8,11 +8,11 @@
 */
 class AdminerEditForeign {
 	var $_limit;
-	
+
 	function __construct($limit = 0) {
 		$this->_limit = $limit;
 	}
-	
+
 	function editInput($table, $field, $attrs, $value) {
 		static $foreignTables = array();
 		static $values = array();
@@ -30,7 +30,8 @@ class AdminerEditForeign {
 					if (preg_match('~binary~', $field["type"])) {
 						$column = "HEX($column)";
 					}
-					$options = array("" => "") + get_vals("SELECT $column FROM " . table($target) . " ORDER BY 1" . ($this->_limit ? " LIMIT " . ($this->_limit + 1) : ""));
+					$options = $field["null"] ? array("" => "") : array();
+					$options += get_vals("SELECT $column FROM " . table($target) . " ORDER BY 1" . ($this->_limit ? " LIMIT " . ($this->_limit + 1) : ""));
 					if ($this->_limit && count($options) - 1 > $this->_limit) {
 						return;
 					}
@@ -39,5 +40,5 @@ class AdminerEditForeign {
 			}
 		}
 	}
-	
+
 }


### PR DESCRIPTION
The null (empty) option is proposed for non null foreign keys which, on insert or update, generates a foreign key constraint error or an inconsistency if the constraint is disabled. The null option should only be displayed for foreign keys that may be null.