### PR TITLE
MSSQL driver fixed for freetds drivers. See bug #167, #291

### DIFF
--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -361,7 +361,9 @@ if (isset($_GET["mssql"])) {
 
 	function fields($table) {
 		$return = array();
-		foreach (get_rows("SELECT c.*, t.name type, d.definition [default]
+		foreach (get_rows("SELECT 
+			c.max_length, c.precision, c.scale, c.name, c.is_nullable, c.is_identity, c.collation_name,
+			t.name type, CAST(d.definition as text) [default]
 FROM sys.all_columns c
 JOIN sys.all_objects o ON c.object_id = o.object_id
 JOIN sys.types t ON c.user_type_id = t.user_type_id


### PR DESCRIPTION
Sometimes (for example on linux servers) there are no other MSSQL driver than freetds. In this case, the query of the table structure may fail.

In the function fields(), line 364 the sql command `"SELECT c.*, t.name type, d.definition [default] FROM ... ` is not good for freetds driver.
If you change it to
```
    "SELECT 
        c.max_length, c.precision, c.scale, c.name, c.is_nullable,
        c.is_identity, c.collation_name, 
        t.name type, CAST(d.definition as text) [default]"
```
the UNICODE error will disapper, and table structure will be shown appropriately.
