### PR TITLE
Encapsulate fulltext part in search box into <div>

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -339,11 +339,11 @@ class Adminer {
 		print_fieldset("search", lang('Search'), $where);
 		foreach ($indexes as $i => $index) {
 			if ($index["type"] == "FULLTEXT") {
-				echo "(<i>" . implode("</i>, <i>", array_map('h', $index["columns"])) . "</i>) AGAINST";
+				echo "<div>(<i>" . implode("</i>, <i>", array_map('h', $index["columns"])) . "</i>) AGAINST";
 				echo " <input type='search' name='fulltext[$i]' value='" . h($_GET["fulltext"][$i]) . "'>";
 				echo script("qsl('input').oninput = selectFieldChange;", "");
 				echo checkbox("boolean[$i]", 1, isset($_GET["boolean"][$i]), "BOOL");
-				echo "<br>\n";
+				echo "</div>\n";
 			}
 		}
 		$_GET["where"] = (array) $_GET["where"];


### PR DESCRIPTION
Search box contains a <div> for each condition. However, fulltext condition is printed inline with <br> at the end. This causes problems when I want to set CSS for search box parts.