### PR TITLE
fix elastic.inc.php to work on PHP 5.2

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -412,7 +412,7 @@ if (isset($_GET["elastic"])) {
 		$properties = array();
 		foreach($fields as $f) {
 			$field_name = trim($f[1][0]);
-			$field_type = trim($f[1][1] ?: "text");
+			$field_type = trim($f[1][1] ? "" : "text");
 			$properties[$field_name] = array(
 				'type' => $field_type
 			);


### PR DESCRIPTION
Without this change, I get the following syntax error on PHP 5.2.6:
PHP Parse error:  syntax error, unexpected ':' in /var/www/adminer/adminer/drivers/elastic.inc.php on line 415

I haven't actually tested the alter_table() method.