### PR TITLE
Fixing exports on PostgreSQL

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -704,7 +704,7 @@ AND typelem = 0"
 		// fields' definitions
 		foreach ($fields as $field_name => $field) {
 			$part = idf_escape($field['field']) . ' ' . $field['full_type']
-				. (is_null($field['default']) ? "" : " DEFAULT $field[default]")
+				. (is_null($field['default']) ? "" : (strpos($field['full_type'], 'character varying') === 0 ? " DEFAULT '$field[default]'" : " DEFAULT $field[default]"))
 				. ($field['attnotnull'] ? " NOT NULL" : "");
 			$return_parts[] = $part;
 

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -711,9 +711,14 @@ AND typelem = 0"
 			// sequences for fields
 			if (preg_match('~nextval\(\'([^\']+)\'\)~', $field['default'], $matches)) {
 				$sequence_name = $matches[1];
-				$sq = reset(get_rows("SELECT * FROM $sequence_name"));
-				$sequences[] = ($style == "DROP+CREATE" ? "DROP SEQUENCE $sequence_name;\n" : "")
-					. "CREATE SEQUENCE $sequence_name INCREMENT $sq[increment_by] MINVALUE $sq[min_value] MAXVALUE $sq[max_value] START " . ($auto_increment ? $sq['last_value'] : 1) . " CACHE $sq[cache_value];";
+				if ($connection->server_info >= 10) {
+					$sqi = reset(get_rows("SELECT * FROM PG_SEQUENCES WHERE SEQUENCENAME = '$sequence_name'"));
+					$sqv = reset(get_rows("SELECT * FROM $sequence_name"));
+					$sequences[] = "CREATE SEQUENCE $sequence_name INCREMENT $sqi[increment_by] MINVALUE $sqi[min_value] MAXVALUE $sqi[max_value] START " . ($auto_increment ? $sqv['last_value'] : 1) . " CACHE $sqi[cache_size];";
+				} else {
+					$sq = reset(get_rows("SELECT * FROM $sequence_name"));
+					$sequences[] = "CREATE SEQUENCE $sequence_name INCREMENT $sq[increment_by] MINVALUE $sq[min_value] MAXVALUE $sq[max_value] START " . ($auto_increment ? $sq['last_value'] : 1) . " CACHE $sq[cache_value];";
+				}
 			}
 		}
 


### PR DESCRIPTION
Since PostgreSQL 10, sequence info have been moved to a new catalog **PG_SEQUENCES** instead of being in the sequence itself, so the export was broken.

Also, not related to the version 10 of PostgreSQL but the export for **character varying** fields didn't put quotes around the default values.