### PR TITLE
Mongodb: implement create_database

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -28,7 +28,7 @@ if (isset($_GET["mongo"])) {
 					return false;
 				}
 			}
-			
+
 			function query($query) {
 				return false;
 			}
@@ -114,7 +114,7 @@ if (isset($_GET["mongo"])) {
 
 		class Min_Driver extends Min_SQL {
 			public $primary = "_id";
-			
+
 			function select($table, $select, $where, $group, $order = array(), $limit = 1, $page = 0, $print = false) {
 				$select = ($select == array("*")
 					? array()
@@ -132,7 +132,7 @@ if (isset($_GET["mongo"])) {
 					->skip($page * $limit)
 				);
 			}
-			
+
 			function insert($table, $set) {
 				try {
 					$return = $this->_conn->_db->selectCollection($table)->insert($set);

--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -171,6 +171,10 @@ if (isset($_GET["mongo"])) {
 			return array_fill_keys($connection->_db->getCollectionNames(true), 'table');
 		}
 
+		function create_database($db, $collation) {
+			return true;
+		}
+
 		function drop_databases($databases) {
 			global $connection;
 			foreach ($databases as $db) {
@@ -434,6 +438,10 @@ if (isset($_GET["mongo"])) {
 				$collections[$result->name] = 'table';
 			}
 			return $collections;
+		}
+
+		function create_database($db, $collation) {
+			return true;
 		}
 
 		function drop_databases($databases) {


### PR DESCRIPTION
Create database fails on MongoDB just because the method is not found although there is no need to actually do anything as MongoDB creates a database only when actual data is written inside it.