### PR TITLE
Do not cast date/timestamp exact searches in PostgreSQL to text

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -194,7 +194,10 @@ if (isset($_GET["pgsql"])) {
 		}
 
 		function convertSearch($idf, $val, $field) {
-			return (preg_match('~char|text' . (is_numeric($val["val"]) && !preg_match('~LIKE~', $val["op"]) ? '|' . number_type() : '') . '~', $field["type"])
+			return (preg_match('~char|text'
+					. (is_numeric($val["val"]) && !preg_match('~LIKE~', $val["op"]) ? '|' . number_type() : '')
+					. (!preg_match('~LIKE~', $val["op"]) ? '|date|timestamp' : '')
+					. '~', $field["type"])
 				? $idf
 				: "CAST($idf AS text)"
 			);


### PR DESCRIPTION
This fixes faulty behaviour when comparing date/timestamp fields with `=`, when value casted to text did not match simple 'YYYY-MM-DD date notation'.