### PR TITLE
PostgreSQL: Do not cast boolean to text on search

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -216,7 +216,7 @@ if (isset($_GET["pgsql"])) {
 
 		function convertSearch($idf, $val, $field) {
 			return (preg_match('~char|text'
-					. (!preg_match('~LIKE~', $val["op"]) ? '|date|time(stamp)?|' . number_type() : '')
+					. (!preg_match('~LIKE~', $val["op"]) ? '|date|time(stamp)?|boolean|' . number_type() : '')
 					. '~', $field["type"])
 				? $idf
 				: "CAST($idf AS text)"


### PR DESCRIPTION
Casting boolean fields to text make bool value search unusable, this addresses it.