### PR TITLE
Fix two errors for PHP 7.2

### DIFF
--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -167,7 +167,6 @@ if (isset($_GET["username"])) {
 	}
 	check_invalid_login();
 	$connection = connect();
-	global $driver;
 	$driver = new Min_Driver($connection);
 }
 

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -167,6 +167,7 @@ if (isset($_GET["username"])) {
 	}
 	check_invalid_login();
 	$connection = connect();
+	global $driver;
 	$driver = new Min_Driver($connection);
 }
 

--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -178,7 +178,7 @@ if (!$error && $_POST) {
 								}
 
 								$start = microtime(true);
-							} while ($connection->next_result());
+							} while ($connection->more_results() && $connection->next_result());
 						}
 
 						$query = substr($query, $offset);


### PR DESCRIPTION
It seems that PHP 7.2 is a bit more strict. For example, I couldn't perform a normal select, because the `$driver` global variable was `null`. When adding the global definition when creating it, it will be solved. Also, you need to call `more_results()` before calling `next_result()`. This is a warning that in our environment  that resulted in an error.

I've included adminer in our own tool, that's why we see these warnings.