### PR TITLE
Allow AdminerTablesFilter plugin to be used with third-party table list plugins

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -1038,9 +1038,9 @@ bodyLoad('<?php echo (is_object($connection) ? preg_replace('~^(\d\.?\d).*~s', '
 		foreach ($tables as $table => $status) {
 			$name = $this->tableName($status);
 			if ($name != "") {
-				echo '<li><a href="' . h(ME) . 'select=' . urlencode($table) . '"' . bold($_GET["select"] == $table || $_GET["edit"] == $table, "select") . ">" . lang('select') . "</a> ";
+				echo '<li data-table-name="' . h($table) . '"><a href="' . h(ME) . 'select=' . urlencode($table) . '"' . bold($_GET["select"] == $table || $_GET["edit"] == $table, "select") . ">" . lang('select') . "</a> ";
 				echo (support("table") || support("indexes")
-					? '<a href="' . h(ME) . 'table=' . urlencode($table) . '"'
+					? '<a data-link="main" href="' . h(ME) . 'table=' . urlencode($table) . '"'
 						. bold(in_array($table, array($_GET["table"], $_GET["create"], $_GET["indexes"], $_GET["foreign"], $_GET["trigger"])), (is_view($status) ? "view" : "structure"))
 						. " title='" . lang('Show structure') . "'>$name</a>"
 					: "<span>$name</span>"

--- a/plugins/tables-filter.php
+++ b/plugins/tables-filter.php
@@ -27,7 +27,7 @@ function tablesFilter(){
 	}
 	var tables = qsa('li', qs('#tables'));
 	for (var i = 0; i < tables.length; i++) {
-		var a = qsa('a', tables[i])[1];
+		var a = qs('a[data-link="main"]', tables[i]);
 		var text = tables[i].getAttribute('data-table-name');
 		if (value == '') {
 			tables[i].className = '';
@@ -55,22 +55,6 @@ if (sessionStorage){
 }
 </script>
 <p class="jsonly"><input id="filter-field" autocomplete="off"><?php echo script("qs('#filter-field').oninput = tablesFilterInput;"); ?>
-<ul id='tables'>
 <?php
-echo script("mixin(qs('#tables'), {onmouseover: menuOver, onmouseout: menuOut});");
-foreach ($tables as $table => $status) {
-	echo '<li data-table-name="' . h($table) . '"><a href="' . h(ME) . 'select=' . urlencode($table) . '"' . bold($_GET["select"] == $table || $_GET["edit"] == $table, "select") . ">" . lang('select') . "</a> ";
-	$name = h($status["Name"]);
-	echo (support("table") || support("indexes")
-		? '<a href="' . h(ME) . 'table=' . urlencode($table) . '"'
-			. bold(in_array($table, array($_GET["table"], $_GET["create"], $_GET["indexes"], $_GET["foreign"], $_GET["trigger"])), (is_view($status) ? "view" : "structure"))
-			. " title='" . lang('Show structure') . "'>$name</a>"
-		: "<span>$name</span>"
-	) . "\n";
-}
-?>
-</ul>
-<?php
-		return true;
 	}
 }


### PR DESCRIPTION
AdminerTablesFilter now doesn't render custom list of tables. This will allow to create plugin for rendering list of table compatible with filter plugin.