### PR TITLE
[mssql] error handling in connect method

### DIFF
--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -147,6 +147,10 @@ if (isset($_GET["mssql"])) {
 				$this->_link = @mssql_connect($server, $username, $password);
 				if ($this->_link) {
 					$result = $this->query("SELECT SERVERPROPERTY('ProductLevel'), SERVERPROPERTY('Edition')");
+					if (!$result) {
+						$this->error = mssql_get_last_message();
+						return false;
+					}
 					$row = $result->fetch_row();
 					$this->server_info = $this->result("sp_server_info 2", 2) . " [$row[0]] $row[1]";
 				} else {


### PR DESCRIPTION
I've tried to connect to Sybase Adaptive Server Enterprise 15 using adminer, because I can connect using pdo_mssql driver with dblib.

But I got status 500 with this message in the logs:
` PHP Fatal error:  Call to a member function fetch_row() on a non-object in /.../adminer/httpdocs/index.php on line 747`

After applying this patch, I got error `Function 'SERVERPROPERTY' not found. If this is a SQLJ function or SQL function, use sp_help to check whether the object exists (sp_help may produce a large amount of output).` displayed properly which is an improvement compared to fatal error.