### PR TITLE
Fixes foreign key pattern in MySQL

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -574,7 +574,7 @@ if (!defined("DRIVER")) {
 	*/
 	function foreign_keys($table) {
 		global $connection, $on_actions;
-		static $pattern = '`(?:[^`]|``)+`';
+		static $pattern = '(?:`(?:[^`]|``)+`)|(?:"(?:[^"]|"")+")';
 		$return = array();
 		$create_table = $connection->result("SHOW CREATE TABLE " . table($table), 1);
 		if ($create_table) {


### PR DESCRIPTION
Foreign keys are not displaying in MySQL when ANSI_QUOTES is enabled because the preg_match_all() is looking specifically for backticks. This fix allows for double quotes as well, so foreign keys are recognized even when ANSI_QUOTES is enabled.