### PR TITLE
Add dump formats php (var_export array) and json

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -819,7 +819,6 @@ class Adminer {
 				$keys = array();
 				$suffix = "";
 				$fetch_function = ($table != '' ? 'fetch_assoc' : 'fetch_row');
-				$rows = array();
 				$i = 0;
 				while ($row = $result->$fetch_function()) {
 					$i++;
@@ -834,17 +833,10 @@ class Adminer {
 						$suffix = ($style == "INSERT+UPDATE" ? "\nON DUPLICATE KEY UPDATE " . implode(", ", $values) : "") . ";\n";
 					}
 					if ($_POST["format"] == "php") {
-						if ($i === 1) {
-							echo "array (\n";
-						}
+						echo $i == 1 ? "array (\n" : ",\n";
 						var_export(array_combine($keys, $row));
-						echo ",\n";
 					} elseif ($_POST["format"] == "json") {
-						if ($i === 1) {
-							echo "[\n";
-						} else {
-							echo ",\n";
-						}
+						echo $i == 1 ? "[\n" : ",\n";
 						echo json_encode(array_combine($keys, $row), defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
 					} elseif ($_POST["format"] != "sql") {
 						if ($style == "table") {
@@ -874,12 +866,8 @@ class Adminer {
 						}
 					}
 				}
-				if ($i) {
-					if ($_POST["format"] == "php") {
-						echo ");\n";
-					} elseif ($_POST["format"] == "json") {
-						echo "\n]\n";
-					}
+				if ($i && in_array($_POST["format"], array("php", "json"))) {
+					echo $_POST["format"] == "php" ? ",\n);\n" : "\n]\n";
 				}
 				if ($buffer) {
 					echo $buffer . $suffix;

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -751,7 +751,7 @@ class Adminer {
 	* @return array empty to disable export
 	*/
 	function dumpFormat() {
-		return array('sql' => 'SQL', 'csv' => 'CSV,', 'csv;' => 'CSV;', 'tsv' => 'TSV');
+		return array('sql' => 'SQL', 'csv' => 'CSV,', 'csv;' => 'CSV;', 'tsv' => 'TSV', 'php' => 'PHP', 'json' => 'JSON');
 	}
 
 	/** Export database structure
@@ -819,7 +819,10 @@ class Adminer {
 				$keys = array();
 				$suffix = "";
 				$fetch_function = ($table != '' ? 'fetch_assoc' : 'fetch_row');
+				$rows = array();
+				$i = 0;
 				while ($row = $result->$fetch_function()) {
+					$i++;
 					if (!$keys) {
 						$values = array();
 						foreach ($row as $val) {
@@ -830,7 +833,20 @@ class Adminer {
 						}
 						$suffix = ($style == "INSERT+UPDATE" ? "\nON DUPLICATE KEY UPDATE " . implode(", ", $values) : "") . ";\n";
 					}
-					if ($_POST["format"] != "sql") {
+					if ($_POST["format"] == "php") {
+						if ($i === 1) {
+							echo "array (\n";
+						}
+						var_export(array_combine($keys, $row));
+						echo ",\n";
+					} elseif ($_POST["format"] == "json") {
+						if ($i === 1) {
+							echo "[\n";
+						} else {
+							echo ",\n";
+						}
+						echo json_encode(array_combine($keys, $row), defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
+					} elseif ($_POST["format"] != "sql") {
 						if ($style == "table") {
 							dump_csv($keys);
 							$style = "INSERT";
@@ -856,6 +872,13 @@ class Adminer {
 							echo $buffer . $suffix;
 							$buffer = $insert . $s;
 						}
+					}
+				}
+				if ($i) {
+					if ($_POST["format"] == "php") {
+						echo ");\n";
+					} elseif ($_POST["format"] == "json") {
+						echo "\n]\n";
 					}
 				}
 				if ($buffer) {

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -833,7 +833,7 @@ class Adminer {
 						$suffix = ($style == "INSERT+UPDATE" ? "\nON DUPLICATE KEY UPDATE " . implode(", ", $values) : "") . ";\n";
 					}
 					if ($_POST["format"] == "php") {
-						echo $i == 1 ? "array (\n" : ",\n";
+						echo $i == 1 ? "<?php\n\nreturn array (\n" : ",\n";
 						var_export(array_combine($keys, $row));
 					} elseif ($_POST["format"] == "json") {
 						echo $i == 1 ? "[\n" : ",\n";
@@ -893,7 +893,11 @@ class Adminer {
 	*/
 	function dumpHeaders($identifier, $multi_table = false) {
 		$output = $_POST["output"];
-		$ext = (preg_match('~sql~', $_POST["format"]) ? "sql" : ($multi_table ? "tar" : "csv")); // multiple CSV packed to TAR
+		if ($_POST["format"] == "php" || $_POST["format"] == "json") {
+			$ext = $_POST["format"];
+		} else {
+			$ext = (preg_match('~sql~', $_POST["format"]) ? "sql" : ($multi_table ? "tar" : "csv")); // multiple CSV packed to TAR
+		}
 		header("Content-Type: " .
 			($output == "gz" ? "application/x-gzip" :
 			($ext == "tar" ? "application/x-tar" :


### PR DESCRIPTION
Sample export:

**php**

```php
array (
array (
  'id' => 9,
  'prop_a' => '1',
  'prop_b' => NULL,
  'prop_c' => '3',
),
array (
  'id' => 10,
  'prop_a' => '3',
  'prop_b' => '2',
  'prop_c' => NULL,
),
);
```

**json**

```json
[
{
    "id": 9,
    "prop_a": "1",
    "prop_b": null,
    "prop_c": "3"
},
{
    "id": 10,
    "prop_a": "3",
    "prop_b": "2",
    "prop_c": null
}
]
```

---
![image](https://user-images.githubusercontent.com/2908547/41910572-3f59d79e-7974-11e8-8983-eda91b73bc21.png)
