### PR TITLE
Virtual columns

### DIFF
--- a/adminer/create.inc.php
+++ b/adminer/create.inc.php
@@ -44,13 +44,21 @@ if ($_POST && !process_fields($row["fields"]) && !$error) {
 			if ($field["field"] != "") {
 				if (!$field["has_default"]) {
 					$field["default"] = null;
+				} elseif (($field["has_default"] == 'STORED') || ($field["has_default"] == 'VIRTUAL')) {
+					$field["virtual"] = "GENERATED ALWAYS AS ({$field['default']}) {$field['has_default']}";
+					$field["collation"] = $field["default"] = null;
 				}
 				if ($key == $row["auto_increment_col"]) {
 					$field["auto_increment"] = true;
 				}
+				if ($orig_field['virtual']) {
+					$orig_field["virtual"] = "GENERATED ALWAYS AS ({$orig_field['expression']}) {$orig_field['virtual']}";
+					$orig_field["collation"] = null;
+				}
+
 				$process_field = process_field($field, $type_field);
 				$all_fields[] = array($field["orig"], $process_field, $after);
-				if ($process_field != process_field($orig_field, $orig_field)) {
+				if ($process_field != process_field($orig_field, null)) {
 					$fields[] = array($field["orig"], $process_field, $after);
 					if ($field["orig"] != "" || $after) {
 						$use_all_fields = true;

--- a/adminer/edit.inc.php
+++ b/adminer/edit.inc.php
@@ -7,6 +7,9 @@ foreach ($fields as $name => $field) {
 	if (!isset($field["privileges"][$update ? "update" : "insert"]) || $adminer->fieldName($field) == "") {
 		unset($fields[$name]);
 	}
+	if (!empty($field['virtual'])) {
+		unset($fields[$name]);
+	}
 }
 
 if ($_POST && !$error && !isset($_GET["select"])) {

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -39,7 +39,7 @@ class Adminer {
 	function bruteForceKey() {
 		return $_SERVER["REMOTE_ADDR"];
 	}
-	
+
 	/** Get server name displayed in breadcrumbs
 	* @param string
 	* @return string HTML code or null
@@ -128,7 +128,7 @@ class Adminer {
 		echo "<p><input type='submit' value='" . lang('Login') . "'>\n";
 		echo checkbox("auth[permanent]", 1, $_COOKIE["adminer_permanent"], lang('Permanent login')) . "\n";
 	}
-	
+
 	/** Get login form field
 	* @param string
 	* @param string HTML
@@ -824,6 +824,12 @@ class Adminer {
 						$values = array();
 						foreach ($row as $val) {
 							$field = $result->fetch_field();
+							if ($_POST["format"] == "sql") {
+								//skip virtual columns
+								if ($f = (isset($fields[$field->name]) ? $fields[$field->name] : null)) {
+									if ($f['virtual']) continue;
+								}
+							}
 							$keys[] = $field->name;
 							$key = idf_escape($field->name);
 							$values[] = "$key = VALUES($key)";
@@ -842,6 +848,11 @@ class Adminer {
 						}
 						foreach ($row as $key => $val) {
 							$field = $fields[$key];
+							//skip virtual columns
+							if ($field['virtual']) {
+								unset($row[$key]);
+								continue;
+							}
 							$row[$key] = ($val !== null
 								? unconvert_field($field, preg_match(number_type(), $field["type"]) && $val != '' ? $val : q(($val === false ? 0 : $val)))
 								: "NULL"

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -1422,6 +1422,8 @@ function edit_form($TABLE, $fields, $row, $update) {
 		echo "<table cellspacing='0'>" . script("qsl('table').onkeydown = editingKeydown;");
 
 		foreach ($fields as $name => $field) {
+			if (!empty($field['virtual'])) continue;
+
 			echo "<tr><th>" . $adminer->fieldName($field);
 			$default = $_GET["set"][bracket_escape($name)];
 			if ($default === null) {
@@ -1437,7 +1439,7 @@ function edit_form($TABLE, $fields, $row, $update) {
 				)
 				: (!$update && $field["auto_increment"]
 					? ""
-					: (isset($_GET["select"]) ? false : $default)
+					: (isset($_GET["select"]) ? false : (empty($field["null"]) ? $default : null))
 				)
 			);
 			if (!$_POST["save"] && is_string($value)) {


### PR DESCRIPTION
I think that I could add support for virtual columns (mysql/mariadb) and do not complicate the editing of the table.
Look here please.
I do not know whether I did everything correctly and did not spoil the editing of other types of databases.

![v-columns](https://user-images.githubusercontent.com/22454101/42747562-9668b872-88e5-11e8-9850-1946e15d84cf.png)

```
CREATE TABLE `my_table` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `date` date NOT NULL DEFAULT '2000-06-01',
  `json_data` text DEFAULT NULL,
  `user_name` varchar(25) GENERATED ALWAYS AS (concat_ws(' ',json_value(`json_data`,'$.first-name'),json_value(`json_data`,'$.last-name'))) STORED,
  `user_age` smallint(5) unsigned GENERATED ALWAYS AS (json_value(`json_data`,'$.about.age')) VIRTUAL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;

INSERT INTO `my_table` (`id`, `date`, `json_data`) VALUES
(9,	'2000-01-01',	'{\"first-name\": \"John\",\"last-name\":\"Doe\",\"about\":{\"age\":27}}');
```
