### PR TITLE
Hide import from server if no path

### DIFF
--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -231,10 +231,12 @@ if (!isset($_GET["import"])) {
 		: lang('File uploads are disabled.')
 	);
 	echo "</div></fieldset>\n";
-	echo "<fieldset><legend>" . lang('From server') . "</legend><div>";
-	echo lang('Webserver file %s', "<code>" . h($adminer->importServerPath()) . "$gz</code>");
-	echo ' <input type="submit" name="webfile" value="' . lang('Run file') . '">';
-	echo "</div></fieldset>\n";
+	if ($adminer->importServerPath()) {
+		echo "<fieldset><legend>" . lang('From server') . "</legend><div>";
+		echo lang('Webserver file %s', "<code>" . h($adminer->importServerPath()) . "$gz</code>");
+		echo ' <input type="submit" name="webfile" value="' . lang('Run file') . '">';
+		echo "</div></fieldset>\n";
+	}
 	echo "<p>";
 }
 


### PR DESCRIPTION
Adds the ability to hide the import from server functionality, for installs where Adminer runs in a location where the user can't upload files.