### PR TITLE
call adminer from plugin

### DIFF
--- a/plugins/plugin.php
+++ b/plugins/plugin.php
@@ -7,6 +7,13 @@
 * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2 (one or other)
 */
 class AdminerPlugin extends Adminer {
+	/**
+	 * propagation allows plugins to run and call parent methods from a reference to the adminer instance
+	 * this is useful for doing things in a plugin before AND/OR after calling adminer function
+	 *
+	 * @access protected
+	 */
+	var $propagation=true;
 	/** @access protected */
 	var $plugins;
 	
@@ -32,26 +39,37 @@ class AdminerPlugin extends Adminer {
 		$this->plugins = $plugins;
 		//! it is possible to use ReflectionObject to find out which plugins defines which methods at once
 	}
-	
+
+	/** Register additional plugin after instantiating the class
+	 * @param $plugin
+	 */
+	function addPlugin($plugin){
+		$this->plugins[] = $plugin;
+	}
+
 	function _callParent($function, $args) {
 		return call_user_func_array(array('parent', $function), $args);
 	}
 	
 	function _applyPlugin($function, $args) {
-		foreach ($this->plugins as $plugin) {
-			if (method_exists($plugin, $function)) {
-				switch (count($args)) { // call_user_func_array() doesn't work well with references
-					case 0: $return = $plugin->$function(); break;
-					case 1: $return = $plugin->$function($args[0]); break;
-					case 2: $return = $plugin->$function($args[0], $args[1]); break;
-					case 3: $return = $plugin->$function($args[0], $args[1], $args[2]); break;
-					case 4: $return = $plugin->$function($args[0], $args[1], $args[2], $args[3]); break;
-					case 5: $return = $plugin->$function($args[0], $args[1], $args[2], $args[3], $args[4]); break;
-					case 6: $return = $plugin->$function($args[0], $args[1], $args[2], $args[3], $args[4], $args[5]); break;
-					default: trigger_error('Too many parameters.', E_USER_WARNING);
-				}
-				if ($return !== null) {
-					return $return;
+		if($this->propagation) {
+			foreach ($this->plugins as $plugin) {
+				if (method_exists($plugin, $function)) {
+					$this->propagation = false;
+					switch (count($args)) { // call_user_func_array() doesn't work well with references
+						case 0: $return = $plugin->$function(); break;
+						case 1: $return = $plugin->$function($args[0]); break;
+						case 2: $return = $plugin->$function($args[0], $args[1]); break;
+						case 3: $return = $plugin->$function($args[0], $args[1], $args[2]); break;
+						case 4: $return = $plugin->$function($args[0], $args[1], $args[2], $args[3]); break;
+						case 5: $return = $plugin->$function($args[0], $args[1], $args[2], $args[3], $args[4]); break;
+						case 6: $return = $plugin->$function($args[0], $args[1], $args[2], $args[3], $args[4], $args[5]); break;
+						default: trigger_error('Too many parameters.', E_USER_WARNING);
+					}
+					$this->propagation = true;
+					if ($return !== null) {
+						return $return;
+					}
 				}
 			}
 		}
@@ -59,12 +77,16 @@ class AdminerPlugin extends Adminer {
 	}
 	
 	function _appendPlugin($function, $args) {
-		$return = $this->_callParent($function, $args);
-		foreach ($this->plugins as $plugin) {
-			if (method_exists($plugin, $function)) {
-				$value = call_user_func_array(array($plugin, $function), $args);
-				if ($value) {
-					$return += $value;
+		if($this->propagation) {
+			$return = $this->_callParent($function, $args);
+			foreach ($this->plugins as $plugin) {
+				if (method_exists($plugin, $function)) {
+					$this->propagation = false;
+					$value = call_user_func_array(array($plugin, $function), $args);
+					if ($value) {
+						$return += $value;
+					}
+					$this->propagation = true;
 				}
 			}
 		}

--- a/plugins/plugin.php
+++ b/plugins/plugin.php
@@ -55,7 +55,6 @@ class AdminerPlugin extends Adminer {
 		if($this->propagation) {
 			foreach ($this->plugins as $plugin) {
 				if (method_exists($plugin, $function)) {
-					$this->propagation = false;
 					switch (count($args)) { // call_user_func_array() doesn't work well with references
 						case 0: $return = $plugin->$function(); break;
 						case 1: $return = $plugin->$function($args[0]); break;
@@ -66,13 +65,13 @@ class AdminerPlugin extends Adminer {
 						case 6: $return = $plugin->$function($args[0], $args[1], $args[2], $args[3], $args[4], $args[5]); break;
 						default: trigger_error('Too many parameters.', E_USER_WARNING);
 					}
-					$this->propagation = true;
 					if ($return !== null) {
 						return $return;
 					}
 				}
 			}
 		}
+		$this->propagation = true;
 		return $this->_callParent($function, $args);
 	}
 	
@@ -81,15 +80,14 @@ class AdminerPlugin extends Adminer {
 			$return = $this->_callParent($function, $args);
 			foreach ($this->plugins as $plugin) {
 				if (method_exists($plugin, $function)) {
-					$this->propagation = false;
 					$value = call_user_func_array(array($plugin, $function), $args);
 					if ($value) {
 						$return += $value;
 					}
-					$this->propagation = true;
 				}
 			}
 		}
+		$this->propagation = true;
 		return $return;
 	}
 	


### PR DESCRIPTION
allow plugins to reference the adminer instance so that any other registered plugin will still be called.. 

Example...

this plugin calls loginForm on the adminer instance after it is called itself.  
this allows for other registered plugins with adminer to work within that call (loginFormField)  

```php
<?php
class AdminerFormWrapper
{
	var $adminer;
	public function __construct(&$adminer)
	{
		$this->adminer =& $adminer;
	}
	function loginForm()
	{
                // prevent plugins from being recursively called...
                $this->adminer->propagation=false;
		?>
		<div id="login-form">
			<?php $this->adminer->loginForm() ?>
		</div>
		<?php
		return true;
	}
}

function adminer_object()
{
	// Required to run any plugin
	include_once './plugins/plugin.php';
	// Plugins auto-loader
	foreach (glob('plugins/*.php') as $filename)
	{
		include_once "./{$filename}";
	}
	// Specify enabled plugins here
	$plugins = [
/** plugins that may have loginFormField defined will still work! */
	];
	$adminer = new AdminerPlugin($plugins);
	// you can add plugins after instantiating the adminer object 
	// in this way, they can use the referenced object!
	$adminer->addPlugin(new AdminerFormWrapper($adminer));
	return $adminer;
}
// Include original Adminer or Adminer Editor
include './adminer-4.6.3.php';
```

the propagation setting prevents recursively calling plugins.