### PR TITLE
dump_headers incorrectly works with empty $output

### DIFF
--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -1105,7 +1105,7 @@ function dump_headers($identifier, $multi_table = false) {
 	$return = $adminer->dumpHeaders($identifier, $multi_table);
 	$output = $_POST["output"];
 	if ($output != "text") {
-		header("Content-Disposition: attachment; filename=" . $adminer->dumpFilename($identifier) . ".$return" . ($output != "file" && !preg_match('~[^0-9a-z]~', $output) ? ".$output" : ""));
+		header("Content-Disposition: attachment; filename=" . $adminer->dumpFilename($identifier) . ".$return" . ($output && $output != "file" && !preg_match('~[^0-9a-z]~', $output) ? ".$output" : ""));
 	}
 	session_write_close();
 	ob_flush();


### PR DESCRIPTION
Fixed case when the `$output` variable is empty. Original version adds dot at the end of file name, f.e.: `file.ext.`