### PR TITLE
Fix mongo authentication

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -620,7 +620,7 @@ if (isset($_GET["mongo"])) {
 		}
 		try {
 			$connection->_link = $connection->connect("mongodb://$server", $options);
-			if ($password != "") {
+			if ($password === "") {
 				$options["password"] = "";
 				try {
 					$connection->connect("mongodb://$server", $options);


### PR DESCRIPTION
When I want to sign in with correct username and password, I get this message: `Database does not support password.`
I think this condetion is incorect.