### PR TITLE
Fix mongo authentication

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -620,15 +620,6 @@ if (isset($_GET["mongo"])) {
 		}
 		try {
 			$connection->_link = $connection->connect("mongodb://$server", $options);
-			if ($password != "") {
-				$options["password"] = "";
-				try {
-					$connection->connect("mongodb://$server", $options);
-					return lang('Database does not support password.');
-				} catch (Exception $ex) {
-					// this is what we want
-				}
-			}
 			return $connection;
 		} catch (Exception $ex) {
 			return $ex->getMessage();


### PR DESCRIPTION
When I want to sign in with correct username and password, I get this message: Database does not support password.
I think this condition is incorrect.
Also, Adminer handles it when the password is empty and return this message: `Adminer does not support accessing a database without a password, more information.`