### PR TITLE
Fix #tables margin on pepa-linha design

### DIFF
--- a/designs/pepa-linha/adminer.css
+++ b/designs/pepa-linha/adminer.css
@@ -336,7 +336,7 @@ p code + a:visited:hover {
 
 #tables {
 	max-height: 100%;
-	margin: 0 -15px !important;
+	margin: 32px -15px !important;
 	position: absolute;
 	left: 15px;
 	right: 15px;


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/2362128/51691378-f4271d80-1ffa-11e9-868a-e1dbffcaa506.png)

**After:**
![image](https://user-images.githubusercontent.com/2362128/51691303-d063d780-1ffa-11e9-92a8-573d548f57aa.png)
