### PR TITLE
Fix too small #lang margin on pepa-linha design

### DIFF
--- a/designs/pepa-linha/adminer.css
+++ b/designs/pepa-linha/adminer.css
@@ -575,7 +575,7 @@ label {
 	top: 55px;
 	right: 100%;
 	z-index: 10;
-	margin-right: -331px;
+	margin-right: -340px;
 	line-height: normal;
 	padding: 0;
 	left: auto;


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/2362128/51837425-9e58bb00-2303-11e9-8e9b-4928ef8dfa29.png)
![image](https://user-images.githubusercontent.com/2362128/51837481-c7794b80-2303-11e9-8b1e-201cdf2220aa.png)


**After:**
![image](https://user-images.githubusercontent.com/2362128/51837474-bcbeb680-2303-11e9-8fcd-0086632baeca.png)
![image](https://user-images.githubusercontent.com/2362128/51837501-d95aee80-2303-11e9-9f50-f7dbf5f23149.png)
