### PR TITLE
Elastic driver - number of records should be count on provided rows

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -84,7 +84,7 @@ if (isset($_GET["elastic"])) {
 			var $num_rows, $_rows;
 
 			function __construct($rows) {
-				$this->num_rows = count($this->_rows);
+				$this->num_rows = count($rows);
 				$this->_rows = $rows;
 				reset($this->_rows);
 			}


### PR DESCRIPTION
Number of the lines in elastic driver should be count on provided lines, not on empty object rows. 
This is solving following warning when you are using elastic driver in PHP 7.3:

_Warning: count(): Parameter must be an array or an object that implements Countable in /var/www/html/adminer.php on line 1228_