### PR TITLE
Elastic driver - show executed query as a json

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -148,7 +148,7 @@ if (isset($_GET["elastic"])) {
 			$start = microtime(true);
 			$search = $this->_conn->query($query, $data);
 			if ($print) {
-				echo $adminer->selectQuery("$query: " . print_r($data, true), $start, !$search);
+				echo $adminer->selectQuery("$query: " . json_encode($data, true), $start, !$search);
 			}
 			if (!$search) {
 				return false;

--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -148,7 +148,7 @@ if (isset($_GET["elastic"])) {
 			$start = microtime(true);
 			$search = $this->_conn->query($query, $data);
 			if ($print) {
-				echo $adminer->selectQuery("$query: " . json_encode($data, true), $start, !$search);
+				echo $adminer->selectQuery("$query: " . json_encode($data), $start, !$search);
 			}
 			if (!$search) {
 				return false;


### PR DESCRIPTION
Elastic search query which has been executed should be display in JSON, as this a true format in which is send  to the Elastic search.

Example:

Instead of:
__doc/_search:_ Array ( [size] => 50 )_

There should be this: 
__doc/_search: {"size":50}_