### PR TITLE
PHP 7.2 throws a warning on next_result when there are none left

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -51,6 +51,14 @@ if (!defined("DRIVER")) {
 				$row = $result->fetch_array();
 				return $row[$field];
 			}
+
+			function next_result( ) {
+				if(parent::more_results()) {
+					return parent::next_result();
+				} else { // No more results
+					return false;
+				}
+			}
 			
 			function quote($string) {
 				return "'" . $this->escape_string($string) . "'";


### PR DESCRIPTION
When executing multiple queries, and having all PHP warnings on (as we have in our environment), I see the following warning:

```
adminer(677): mysqli::next_result(): There is no next result set. Please, call mysqli_more_results()/mysqli::more_results() to check whether to call this function/method(code: 0)
smarty_internal_errorhandler(106): exception_error_handler(2048, mysqli::next_result(): There is no next result set. Please, call mysqli_more_results()/mysqli::more_results() to check whether to call this function/method, /.../adminer.php, 677, Array)
(): mutingErrorHandler(2048, mysqli::next_result(): There is no next result set. Please, call mysqli_more_results()/mysqli::more_results() to check whether to call this function/method, /var/www/zms/system/libraries/dl3b.php, 677, Array)
adminer(677): next_result()
...
```

This addition will always check if there are more result before really calling the next result.
