### PR TITLE
Always pass current geometry property with GeomFromText property

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -1077,7 +1077,7 @@ if (!defined("DRIVER")) {
 			$return = "CONV($return, 2, 10) + 0";
 		}
 		if (preg_match("~geometry|point|linestring|polygon~", $field["type"])) {
-		    $field_name = $field['field'];
+			$field_name = $field['field'];
 			$return = (min_version(8) ? "ST_" : "") . "GeomFromText($return, SRID($field_name))";
 		}
 		return $return;

--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -1077,7 +1077,8 @@ if (!defined("DRIVER")) {
 			$return = "CONV($return, 2, 10) + 0";
 		}
 		if (preg_match("~geometry|point|linestring|polygon~", $field["type"])) {
-			$return = (min_version(8) ? "ST_" : "") . "GeomFromText($return)";
+		    $field_name = $field['field'];
+			$return = (min_version(8) ? "ST_" : "") . "GeomFromText($return, SRID($field_name))";
 		}
 		return $return;
 	}


### PR DESCRIPTION
# What's this
In our database we have store the geometry properties with an SRID (4326) property. In mysql it is possible to pass this property as a second argument with the `GeomFromText` function. 

Adminer does not pass this second argument and thus resets the SRID property when updating. This PR fixes this by respecting the set SRID property on the column updating.

I tested this code on the insert item feature of Adminer and it in the cases I tested this change it doesn't break anything.