### PR TITLE
Cache busting for adminer css

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -108,7 +108,7 @@ class Adminer {
 		$return = array();
 		$filename = "adminer.css";
 		if (file_exists($filename)) {
-            $return[] = $filename. '?'.hash_file ('CRC32', $filename , FALSE );
+			$return[] = $filename. '?'.hash_file ('CRC32', $filename , FALSE );
 		}
 		return $return;
 	}

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -108,7 +108,7 @@ class Adminer {
 		$return = array();
 		$filename = "adminer.css";
 		if (file_exists($filename)) {
-			$return[] = $filename;
+            $return[] = $filename. '?'.hash_file ('CRC32', $filename , FALSE );
 		}
 		return $return;
 	}


### PR DESCRIPTION
When you develop a customised adminer.css to skin adminer, one problem you may face is that changes don't apply to your users until they force-refresh or clear their cache, since the adminer.css file may cache out in either the user's local cache or any intermediate caches or CDN's

The standard way round this is to add a hash to the url that changes when the file changes (adminer does this itself with it's own CSS, using the version number).  

This PR computes a simple (fast) CRC32 hash of the file and adds it to the url.  This means the file will cache and you will experience all the performance benefits of that, but when changed the new version will also be downloaded