### PR TITLE
Provide default value for the parameter in the __construct function to prevent fatal PHP 7.2 error

### DIFF
--- a/plugins/pretty-json-column.php
+++ b/plugins/pretty-json-column.php
@@ -6,7 +6,7 @@ class AdminerPrettyJsonColumn {
 	/** @var AdminerPlugin */
 	protected $adminer;
 
-	public function __construct($adminer) {
+	public function __construct($adminer = null) {
 		$this->adminer = $adminer;
 	}
 


### PR DESCRIPTION
I'm using PHP 7.2, and I got a fatal error when trying to use this plugin due to `public function __construct($adminer)` not being provided `$adminer` at all times. As such, giving it a default/fallback value resolved the issue while retaining the existing functionality.