### PR TITLE
Allow bruteForceKey to be overwritten

### DIFF
--- a/plugins/plugin.php
+++ b/plugins/plugin.php
@@ -110,6 +110,11 @@ class AdminerPlugin extends Adminer {
 		return $this->_applyPlugin(__FUNCTION__, $args);
 	}
 
+	function bruteForceKey() {
+		$args = func_get_args();
+		return $this->_applyPlugin(__FUNCTION__, $args);
+	}
+
 	function serverName($server) {
 		$args = func_get_args();
 		return $this->_applyPlugin(__FUNCTION__, $args);


### PR DESCRIPTION
As per Documentation (https://www.adminer.org/en/extension/#api) bruteForceKey can be overwritten by plugins. This change actually allows for that to happen.