### PR TITLE
pgsql: fix column comment when creating table

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -507,7 +507,7 @@ WHERE table_schema = current_schema() AND table_name = " . q($name))));
 					}
 				}
 				if ($field[0] != "" || $val5 != "") {
-					$queries[] = "COMMENT ON COLUMN " . table($table) . ".$val[0] IS " . ($val5 != "" ? substr($val5, 9) : "''");
+					$queries[] = "COMMENT ON COLUMN " . table(($table == "" ? $name : $table)) . ".$val[0] IS " . ($val5 != "" ? substr($val5, 9) : "''");
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the pgsql driver. When creating a new table, it wasn't possible to add column comments at the same time, because it failed with:
```
CREATE TABLE "table1" (
  "col1" integer NOT NULL
);
COMMENT ON COLUMN ""."col1" IS 'col1 comment';

-- ERROR: zero-length delimited identifier at or near """"
-- LINE 1: COMMENT ON COLUMN ""."col1" IS 'col1 comment'
```