### PR TITLE
Fix the SQL command button after updating a record

### DIFF
--- a/adminer/static/functions.js
+++ b/adminer/static/functions.js
@@ -620,6 +620,9 @@ function ajax(url, callback, data, message) {
 					ajaxStatus.innerHTML = (request.status ? request.responseText : '<div class="error">' + offlineMessage + '</div>');
 					ajaxStatus.className = ajaxStatus.className.replace(/ hidden/g, '');
 				}
+				// Register the "SQL command" button to expand the hidden SQL editor when clicked.
+				// This had been attempted to called using an inline script tag in the innerHTML but it doesn't execute. So let's call it here after the innerHTML has been set.
+				messagesPrint();
 			}
 		};
 		request.send(data);


### PR DESCRIPTION
After updating a record and clicking "Save and continue edit" the green success message displays "Item has been updated. 08:25:00 SQL command".
The button here though doesn't trigger.

This patch fixes this button so it will show the SQL command used to execute the update as expected.