### PR TITLE
pgsql export constraints

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -436,6 +436,23 @@ ORDER BY conkey, conname") as $row) {
 		return $return;
 	}
 
+	function constraints($table) {
+		global $on_actions;
+		$return = array();
+		foreach (get_rows("SELECT conname, consrc
+FROM pg_catalog.pg_constraint
+INNER JOIN pg_catalog.pg_namespace ON pg_constraint.connamespace = pg_namespace.oid
+INNER JOIN pg_catalog.pg_class ON pg_constraint.conrelid = pg_class.oid AND pg_constraint.connamespace = pg_class.relnamespace
+WHERE pg_constraint.contype = 'c'
+AND conrelid != 0 -- handle only CONSTRAINTs here, not TYPES
+AND nspname = current_schema()
+AND relname = " . q($table) . "
+ORDER BY connamespace, conname") as $row) {
+			$return[$row['conname']] = $row['consrc'];
+		}
+		return $return;
+	}
+
 	function view($name) {
 		global $connection;
 		return array("select" => trim($connection->result("SELECT pg_get_viewdef(" . $connection->result("SELECT oid FROM pg_class WHERE relname = " . q($name)) . ")")));
@@ -713,6 +730,7 @@ AND typelem = 0"
 		ksort($indexes);
 		$fkeys = foreign_keys($table);
 		ksort($fkeys);
+		$constraints = constraints($table);
 
 		if (!$status || empty($fields)) {
 			return false;
@@ -756,6 +774,13 @@ AND typelem = 0"
 		foreach ($fkeys as $fkey_name => $fkey) {
 			$return_parts[] = "CONSTRAINT " . idf_escape($fkey_name) . " $fkey[definition] " . ($fkey['deferrable'] ? 'DEFERRABLE' : 'NOT DEFERRABLE');
 		}
+
+		//constraints
+		foreach ($constraints as $conname => $consrc) {
+			$return_parts[] = "CONSTRAINT " . idf_escape($conname) . " CHECK " . $consrc;
+		}
+
+//$return .= "\n\n" . var_export($constraints, true) . "\n\n";
 
 		$return .= implode(",\n    ", $return_parts) . "\n) WITH (oids = " . ($status['Oid'] ? 'true' : 'false') . ");";
 

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -730,7 +730,7 @@ AND typelem = 0"
 		ksort($fkeys);
 
 		foreach ($fkeys as $fkey_name => $fkey) {
-			$return .= "ALTER TABLE ONLY " . idf_escape($status['nspname']) . "." . idf_escape($status['Name']) . " ADD CONSTRAINT " . idf_escape($fkey_name) . " $fkey[definition] " . ($fkey['deferrable'] ? 'DEFERRABLE' : 'NOT DEFERRABLE');
+			$return .= "ALTER TABLE ONLY " . idf_escape($status['nspname']) . "." . idf_escape($status['Name']) . " ADD CONSTRAINT " . idf_escape($fkey_name) . " $fkey[definition] " . ($fkey['deferrable'] ? 'DEFERRABLE' : 'NOT DEFERRABLE') . ";\n";
 		}
 
 		return $return;
@@ -793,8 +793,6 @@ AND typelem = 0"
 			$return_parts[] = "CONSTRAINT " . idf_escape($conname) . " CHECK " . $consrc;
 		}
 
-//$return .= "\n\n" . var_export($constraints, true) . "\n\n";
-
 		$return .= implode(",\n    ", $return_parts) . "\n) WITH (oids = " . ($status['Oid'] ? 'true' : 'false') . ");";
 
 		// "basic" indexes after table definition
@@ -818,9 +816,6 @@ AND typelem = 0"
 				$return .= "\n\nCOMMENT ON COLUMN " . idf_escape($status['nspname']) . "." . idf_escape($status['Name']) . "." . idf_escape($field_name) . " IS " . q($field['comment']) . ";";
 			}
 		}
-
-$return .= "\n\n-- FKs\n";
-$return .= foreign_keys_sql($table);
 
 		return rtrim($return, ';');
 	}

--- a/adminer/dump.inc.php
+++ b/adminer/dump.inc.php
@@ -105,6 +105,17 @@ SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
 					}
 				}
 
+				// add FKs after creating tables (except in mysql which uses SET FOREIGN_KEY_CHECKS=0;)
+				if (function_exists('foreign_keys_sql')) {
+					foreach (table_status('', true) as $name => $table_status) {
+						$table = (DB == "" || in_array($name, (array) $_POST["tables"]));
+						$data = (DB == "" || in_array($name, (array) $_POST["data"]));
+						if ($table && !is_view($table_status)) {
+							echo foreign_keys_sql($name)."\n";
+						}
+					}
+				}
+
 				foreach ($views as $view) {
 					$adminer->dumpTable($view, $_POST["table_style"], 1);
 				}


### PR DESCRIPTION
Adds features to export in the pgsql driver.

Partially fixes [bug#587](https://sourceforge.net/p/adminer/bugs-and-features/587/).

- export constraints (except TYPEs, to be added)
- first create all tables, only then create all FK constraints (avoids reordering CREATE TABLE statements on order of their FK dependency)
