### PR TITLE
setup Mongo authSource by ENV

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -618,6 +618,9 @@ if (isset($_GET["mongo"])) {
 		if ($db != "") {
 			$options["db"] = $db;
 		}
+		if($auth_source = getenv("MONGO_AUTH_SOURCE")) {
+            $options["authSource"] = $auth_source;
+        }
 		try {
 			$connection->_link = $connection->connect("mongodb://$server", $options);
 			if ($password != "") {


### PR DESCRIPTION
Enable setup Mongo connection option [authSource](https://www.php.net/manual/en/mongoclient.construct.php) by environment variable.

It's required when credentials are stored in separe collection. 

ENV variable is easiest way for use by docker. 