### PR TITLE
High-DPI layout

### DIFF
--- a/adminer/static/default.css
+++ b/adminer/static/default.css
@@ -23,7 +23,8 @@ code { background: #eee; }
 tbody tr:hover td, tbody tr:hover th { background: #eee; }
 pre { margin: 1em 0 0; }
 pre, textarea { font: 100%/1.25 monospace; }
-input { vertical-align: middle; }
+select { font-size: inherit; }
+input { vertical-align: middle; font-size: inherit; }
 input.default { box-shadow: 1px 1px 1px #777; }
 input.required { box-shadow: 1px 1px 1px red; }
 input.maxlength { box-shadow: 1px 1px 1px red; }


### PR DESCRIPTION
On a high-DPI machine, using firefox, input and select elements are way smaller than other elements (see attached image). While this is most likely a bug in the browser in combination with invalid scaling settings in gtk, fixing it shouldn't break behavior for other setups.

![2019-12-12-110753_472x171_scrot](https://user-images.githubusercontent.com/6330094/70703161-cc52ae00-1ccf-11ea-956e-ac8cc56f499b.png)
