### PR TITLE
Plugin login-ip wrong string comparison

### DIFF
--- a/plugins/login-ip.php
+++ b/plugins/login-ip.php
@@ -23,7 +23,7 @@ class AdminerLoginIp {
 
 	function login($login, $password) {
 		foreach ($this->ips as $ip) {
-			if (strncasecmp($_SERVER["REMOTE_ADDR"], $ip, strlen($ip))) {
+			if (!strncasecmp($_SERVER["REMOTE_ADDR"], $ip, strlen($ip))) {
 				if (!$this->forwarded_for) {
 					return true;
 				}

--- a/plugins/login-ip.php
+++ b/plugins/login-ip.php
@@ -23,7 +23,7 @@ class AdminerLoginIp {
 
 	function login($login, $password) {
 		foreach ($this->ips as $ip) {
-			if (!strncasecmp($_SERVER["REMOTE_ADDR"], $ip, strlen($ip))) {
+			if (strncasecmp($_SERVER["REMOTE_ADDR"], $ip, strlen($ip)) === 0) {
 				if (!$this->forwarded_for) {
 					return true;
 				}


### PR DESCRIPTION
Function `strncasecmp` returns `0` when two strings are identical. So to go inside the if branch when two string are identical the `strncasecmp` result needs to be negated. 