### PR TITLE
Fix forwarded IP comparison in login-ip plugin

### DIFF
--- a/plugins/login-ip.php
+++ b/plugins/login-ip.php
@@ -29,7 +29,7 @@ class AdminerLoginIp {
 				}
 				if ($_SERVER["HTTP_X_FORWARDED_FOR"]) {
 					foreach ($this->forwarded_for as $forwarded_for) {
-						if (strncasecmp(preg_replace('~.*, *~', '', $_SERVER["HTTP_X_FORWARDED_FOR"]), $forwarded_for, strlen($forwarded_for))) {
+						if (strncasecmp(preg_replace('~.*, *~', '', $_SERVER["HTTP_X_FORWARDED_FOR"]), $forwarded_for, strlen($forwarded_for)) == 0) {
 							return true;
 						}
 					}


### PR DESCRIPTION
The issue described in #372 is the same for the HTTP_X_FORWARDED_FOR comparison. strncasecmp returns 0 when the two strings are equal which is falsey.