### PR TITLE
BLOB QoL on sqlite

### DIFF
--- a/adminer/drivers/sqlite.inc.php
+++ b/adminer/drivers/sqlite.inc.php
@@ -774,10 +774,17 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 	}
 
 	function convert_field($field) {
+		if ($field["type"] === 'blob') {
+			return "HEX(" . idf_escape($field["field"]) . ")";
+		}
 	}
 
 	function unconvert_field($field, $return) {
-		return $return;
+		if ($field["type"] === 'blob') {
+			return "X$return";
+		}
+
+        return $return;
 	}
 
 	function support($feature) {

--- a/adminer/select.inc.php
+++ b/adminer/select.inc.php
@@ -398,10 +398,7 @@ if (!$columns && support("table")) {
 						}
 
 						$link = "";
-						if (preg_match('~blob|bytea|raw|file~', $field["type"]) && $val != "") {
-							$link = ME . 'download=' . urlencode($TABLE) . '&field=' . urlencode($key) . $unique_idf;
-						}
-						if (!$link && $val !== null) { // link related items
+						if ($val !== null) { // link related items
 							foreach ((array) $foreign_keys[$key] as $foreign_key) {
 								if (count($foreign_keys[$key]) == 1 || end($foreign_key["source"]) == $key) {
 									$link = "";
@@ -417,6 +414,9 @@ if (!$columns && support("table")) {
 									}
 								}
 							}
+						}
+						if (!$link && preg_match('~blob|bytea|raw|file~', $field["type"]) && $val != "") {
+							$link = ME . 'download=' . urlencode($TABLE) . '&field=' . urlencode($key) . $unique_idf;
 						}
 						if ($key == "COUNT(*)") { //! columns looking like functions
 							$link = ME . "select=" . urlencode($TABLE);


### PR DESCRIPTION
1. If you have UUIDs stored as BLOB and used as foreign keys, Adminer would
create a link to download the binary version of the UUID rather than
linking to the FK destination.

2. Implement hex/unhex for sqlite.