### PR TITLE
Hide sqlite_sequence table in the database schema

### DIFF
--- a/adminer/schema.inc.php
+++ b/adminer/schema.inc.php
@@ -19,9 +19,9 @@ foreach (table_status('', true) as $table => $table_status) {
 	if (is_view($table_status)) {
 		continue;
 	}
-    if ($drivers[DRIVER] == 'SQLite 3' && $table_status['Name'] == 'sqlite_sequence') {
-        continue;
-    }
+	if ($drivers[DRIVER] == 'SQLite 3' && $table_status['Name'] == 'sqlite_sequence') {
+		continue;
+	}
 	$pos = 0;
 	$schema[$table]["fields"] = array();
 	foreach (fields($table) as $name => $field) {

--- a/adminer/schema.inc.php
+++ b/adminer/schema.inc.php
@@ -19,6 +19,9 @@ foreach (table_status('', true) as $table => $table_status) {
 	if (is_view($table_status)) {
 		continue;
 	}
+    if ($drivers[DRIVER] == 'SQLite 3' && $table_status['Name'] == 'sqlite_sequence') {
+        continue;
+    }
 	$pos = 0;
 	$schema[$table]["fields"] = array();
 	foreach (fields($table) as $name => $field) {


### PR DESCRIPTION
The table `sqlite_sequence` is an "internal table"  (for the AI) of SQLite3.
I think that this table must not figure on the database schema.

Thanks for adminer.