### PR TITLE
Small readability improvements in pepa-linha theme

### DIFF
--- a/designs/pepa-linha/adminer.css
+++ b/designs/pepa-linha/adminer.css
@@ -353,7 +353,7 @@ p code + a:visited:hover {
 
 #tables a {
 	float: right;
-	padding: 6px 15px;
+	padding: 2px 15px;
 }
 
 .rtl #tables a {
@@ -363,6 +363,8 @@ p code + a:visited:hover {
 #tables a[title] {
 	float: none;
 	display: block;
+	overflow: hidden;
+	width: calc(100% - 125px);
 }
 
 .rtl #tables a:first-child,
@@ -372,11 +374,15 @@ p code + a:visited:hover {
 	margin-left: 15px;
 }
 
+#tables li:hover {
+    background: #EEE;
+}
+
 #tables a:hover,
-#tables a:hover + a,
 #tables a.active,
 #tables a.active + a {
-	background: #fff;
+	background: #EEE;
+	display: inline-table;
 	color: #2e84e4;
 }
 
@@ -472,8 +478,10 @@ table:not(#table) input[type="password"],
 table:not(#table) input[type="tel"],
 table:not(#table) input[type="url"],
 table:not(#table) input[type="text"],
-table:not(#table) input[type="search"] {
+table:not(#table) input[type="search"],
+table:not(#table) textarea {
 	min-width: 280px;
+	width: calc(100vw - 800px);
 }
 
 input[type=submit],

--- a/designs/pepa-linha/adminer.css
+++ b/designs/pepa-linha/adminer.css
@@ -481,7 +481,6 @@ table:not(#table) input[type="text"],
 table:not(#table) input[type="search"],
 table:not(#table) textarea {
 	min-width: 280px;
-	width: calc(100vw - 800px);
 }
 
 input[type=submit],


### PR DESCRIPTION
I've added some really small readability improvements on long table names support

Idle
![image](https://user-images.githubusercontent.com/659492/82903398-2cc56700-9f61-11ea-8c31-19199ff6efe4.png)

Hovering table structure
![image](https://user-images.githubusercontent.com/659492/82903437-3c44b000-9f61-11ea-82dc-cd2cecd31b5e.png)

Hovering the "select" button
![image](https://user-images.githubusercontent.com/659492/82903481-4d8dbc80-9f61-11ea-98f2-244a5af513ca.png)
