### PR TITLE
Adminer mongodb driver fix bug

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -624,10 +624,9 @@ if (isset($_GET["mongo"])) {
 		try {
 			$connection->_link = $connection->connect("mongodb://$server", $options);
 			if ($password != "") {
-				$options["password"] = "";
+				$options["password"] = $password;
 				try {
 					$connection->connect("mongodb://$server", $options);
-					return lang('Database does not support password.');
 				} catch (Exception $ex) {
 					// this is what we want
 				}


### PR DESCRIPTION
fix bug: log in mongodb error: "Database does not support password", but the user name and password are correct and it is required,and user can not log in successfully. The error message and logic make people feel very strange.