### PR TITLE
Various PHP 8 fixes

### DIFF
--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -73,7 +73,7 @@ if ($auth) {
 		redirect(auth_url($vendor, $server, $username, $db));
 	}
 	
-} elseif ($_POST["logout"]) {
+} elseif (isset($_POST["logout"])) {
 	if ($has_token && !verify_token()) {
 		page_header(lang('Logout'), lang('Invalid CSRF token. Send the form again.'));
 		page_footer("db");

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -48,7 +48,7 @@ function check_invalid_login() {
 	}
 }
 
-$auth = $_POST["auth"];
+$auth = isset($_POST["auth"]) ? $_POST["auth"] : null;
 if ($auth) {
 	session_regenerate_id(); // defense against session fixation
 	$vendor = $auth["driver"];

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -8,7 +8,7 @@ if (!$has_token) {
 $token = get_token(); ///< @var string CSRF protection
 
 $permanent = array();
-if ($_COOKIE["adminer_permanent"]) {
+if (!empty($_COOKIE["adminer_permanent"])) {
 	foreach (explode(" ", $_COOKIE["adminer_permanent"]) as $val) {
 		list($key) = explode(":", $val);
 		$permanent[$key] = $val;

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -136,7 +136,7 @@ function auth_error($error) {
 		$error = lang('Session support must be enabled.');
 	}
 	$params = session_get_cookie_params();
-	cookie("adminer_key", ($_COOKIE["adminer_key"] ? $_COOKIE["adminer_key"] : rand_string()), $params["lifetime"]);
+	cookie("adminer_key", (!empty($_COOKIE["adminer_key"]) ? $_COOKIE["adminer_key"] : rand_string()), $params["lifetime"]);
 	page_header(lang('Login'), $error, null);
 	echo "<form action='' method='post'>\n";
 	echo "<div>";

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -41,7 +41,7 @@ if (!$_SERVER["REQUEST_URI"]) { // IIS 5 compatibility
 if (!strpos($_SERVER["REQUEST_URI"], '?') && isset($_SERVER["QUERY_STRING"]) && $_SERVER["QUERY_STRING"] != "") { // IIS 7 compatibility
 	$_SERVER["REQUEST_URI"] .= "?$_SERVER[QUERY_STRING]";
 }
-if ($_SERVER["HTTP_X_FORWARDED_PREFIX"]) {
+if (isset($_SERVER["HTTP_X_FORWARDED_PREFIX"]) && $_SERVER["HTTP_X_FORWARDED_PREFIX"]) {
 	$_SERVER["REQUEST_URI"] = $_SERVER["HTTP_X_FORWARDED_PREFIX"] . $_SERVER["REQUEST_URI"];
 }
 $HTTPS = ($_SERVER["HTTPS"] && strcasecmp($_SERVER["HTTPS"], "off")) || ini_bool("session.cookie_secure"); // session.cookie_secure could be set on HTTP if we are behind a reverse proxy

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -82,7 +82,7 @@ include "../adminer/drivers/elastic.inc.php";
 include "../adminer/drivers/clickhouse.inc.php";
 include "../adminer/drivers/mysql.inc.php"; // must be included as last driver
 
-define("SERVER", $_GET[DRIVER]); // read from pgsql=localhost
+define("SERVER", isset($_GET[DRIVER]) ? $_GET[DRIVER] : ''); // read from pgsql=localhost
 define("DB", isset($_GET["db"]) ? $_GET["db"] : ''); // for the sake of speed and size
 define("ME", str_replace(":", "%3a", preg_replace('~\?.*~', '', relative_uri())) . '?'
 	. (sid() ? SID . '&' : '')

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -83,7 +83,7 @@ include "../adminer/drivers/clickhouse.inc.php";
 include "../adminer/drivers/mysql.inc.php"; // must be included as last driver
 
 define("SERVER", $_GET[DRIVER]); // read from pgsql=localhost
-define("DB", $_GET["db"]); // for the sake of speed and size
+define("DB", isset($_GET["db"]) ? $_GET["db"] : ''); // for the sake of speed and size
 define("ME", str_replace(":", "%3a", preg_replace('~\?.*~', '', relative_uri())) . '?'
 	. (sid() ? SID . '&' : '')
 	. (SERVER !== null ? DRIVER . "=" . urlencode(SERVER) . '&' : '')

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -38,7 +38,7 @@ global $adminer, $connection, $driver, $drivers, $edit_functions, $enum_length, 
 if (!$_SERVER["REQUEST_URI"]) { // IIS 5 compatibility
 	$_SERVER["REQUEST_URI"] = $_SERVER["ORIG_PATH_INFO"];
 }
-if (!strpos($_SERVER["REQUEST_URI"], '?') && $_SERVER["QUERY_STRING"] != "") { // IIS 7 compatibility
+if (!strpos($_SERVER["REQUEST_URI"], '?') && isset($_SERVER["QUERY_STRING"]) && $_SERVER["QUERY_STRING"] != "") { // IIS 7 compatibility
 	$_SERVER["REQUEST_URI"] .= "?$_SERVER[QUERY_STRING]";
 }
 if ($_SERVER["HTTP_X_FORWARDED_PREFIX"]) {

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -25,7 +25,7 @@ if (isset($_GET["file"])) {
 	include "../adminer/file.inc.php";
 }
 
-if ($_GET["script"] == "version") {
+if (isset($_GET["script"]) && $_GET["script"] == "version") {
 	$fp = file_open_lock(get_temp_dir() . "/adminer.version");
 	if ($fp) {
 		file_write_unlock($fp, serialize(array("signature" => $_POST["signature"], "version" => $_POST["version"])));

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -44,7 +44,7 @@ if (!strpos($_SERVER["REQUEST_URI"], '?') && isset($_SERVER["QUERY_STRING"]) && 
 if (isset($_SERVER["HTTP_X_FORWARDED_PREFIX"]) && $_SERVER["HTTP_X_FORWARDED_PREFIX"]) {
 	$_SERVER["REQUEST_URI"] = $_SERVER["HTTP_X_FORWARDED_PREFIX"] . $_SERVER["REQUEST_URI"];
 }
-$HTTPS = ($_SERVER["HTTPS"] && strcasecmp($_SERVER["HTTPS"], "off")) || ini_bool("session.cookie_secure"); // session.cookie_secure could be set on HTTP if we are behind a reverse proxy
+$HTTPS = (!empty($_SERVER["HTTPS"]) && strcasecmp($_SERVER["HTTPS"], "off")) || ini_bool("session.cookie_secure"); // session.cookie_secure could be set on HTTP if we are behind a reverse proxy
 
 @ini_set("session.use_trans_sid", false); // protect links in export, @ - may be disabled
 if (!defined("SID")) {

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -60,7 +60,7 @@ if (!defined("SID")) {
 
 // disable magic quotes to be able to use database escaping function
 remove_slashes(array(&$_GET, &$_POST, &$_COOKIE), $filter);
-if (get_magic_quotes_runtime()) {
+if (function_exists('get_magic_quotes_runtime') && get_magic_quotes_runtime()) {
 	set_magic_quotes_runtime(false);
 }
 @set_time_limit(0); // @ - can be disabled

--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -159,7 +159,7 @@ function get_nonce() {
 */
 function page_messages($error) {
 	$uri = preg_replace('~^[^?]*~', '', $_SERVER["REQUEST_URI"]);
-	$messages = $_SESSION["messages"][$uri];
+	$messages = !empty($_SESSION["messages"][$uri]) ? $_SESSION["messages"][$uri] : null;
 	if ($messages) {
 		echo "<div class='message'>" . implode("</div>\n<div class='message'>", $messages) . "</div>" . script("messagesPrint();");
 		unset($_SESSION["messages"][$uri]);

--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -35,7 +35,7 @@ function page_header($title, $error = "", $breadcrumb = array(), $title2 = "") {
 <body class="<?php echo lang('ltr'); ?> nojs">
 <?php
 	$filename = get_temp_dir() . "/adminer.version";
-	if (!$_COOKIE["adminer_version"] && function_exists('openssl_verify') && file_exists($filename) && filemtime($filename) + 86400 > time()) { // 86400 - 1 day in seconds
+	if (empty($_COOKIE["adminer_version"]) && function_exists('openssl_verify') && file_exists($filename) && filemtime($filename) + 86400 > time()) { // 86400 - 1 day in seconds
 		$version = unserialize(file_get_contents($filename));
 		$public = "-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwqWOVuF5uw7/+Z70djoK

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -615,7 +615,7 @@ function auth_url($vendor, $server, $username, $db = null) {
 * @return bool
 */
 function is_ajax() {
-	return ($_SERVER["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest");
+	return (!empty($_SERVER["HTTP_X_REQUESTED_WITH"]) && $_SERVER["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest");
 }
 
 /** Send Location header and exit

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -62,7 +62,7 @@ function number_type() {
 * @return null modified in place
 */
 function remove_slashes($process, $filter = false) {
-	if (get_magic_quotes_gpc()) {
+	if (function_exists('get_magic_quotes_runtime') && get_magic_quotes_gpc()) {
 		while (list($key, $val) = each($process)) {
 			foreach ($val as $k => $v) {
 				unset($process[$key][$k]);

--- a/adminer/include/lang.inc.php
+++ b/adminer/include/lang.inc.php
@@ -104,7 +104,7 @@ $LANG = "en";
 if (isset($_COOKIE["adminer_lang"]) && isset($langs[$_COOKIE["adminer_lang"]])) {
 	cookie("adminer_lang", $_COOKIE["adminer_lang"]);
 	$LANG = $_COOKIE["adminer_lang"];
-} elseif (isset($langs[$_SESSION["lang"]])) {
+} elseif (isset($_SESSION["lang"]) && isset($langs[$_SESSION["lang"]])) {
 	$LANG = $_SESSION["lang"];
 } else {
 	$accept_language = array();

--- a/adminer/include/lang.inc.php
+++ b/adminer/include/lang.inc.php
@@ -62,7 +62,7 @@ function get_lang() {
 */
 function lang($idf, $number = null) {
 	global $LANG, $translations;
-	$translation = ($translations[$idf] ? $translations[$idf] : $idf);
+	$translation = (isset($translations[$idf]) && $translations[$idf] ? $translations[$idf] : $idf);
 	if (is_array($translation)) {
 		$pos = ($number == 1 ? 0
 			: ($LANG == 'cs' || $LANG == 'sk' ? ($number && $number < 5 ? 1 : 2) // different forms for 1, 2-4, other

--- a/adminer/include/lang.inc.php
+++ b/adminer/include/lang.inc.php
@@ -101,7 +101,7 @@ if (isset($_POST["lang"]) && verify_token()) { // $error not yet available
 }
 
 $LANG = "en";
-if (isset($langs[$_COOKIE["adminer_lang"]])) {
+if (isset($_COOKIE["adminer_lang"]) && isset($langs[$_COOKIE["adminer_lang"]])) {
 	cookie("adminer_lang", $_COOKIE["adminer_lang"]);
 	$LANG = $_COOKIE["adminer_lang"];
 } elseif (isset($langs[$_SESSION["lang"]])) {

--- a/adminer/include/pdo.inc.php
+++ b/adminer/include/pdo.inc.php
@@ -24,7 +24,7 @@ if (extension_loaded('pdo')) {
 		
 		/*abstract function select_db($database);*/
 		
-		function query($query, $unbuffered = false) {
+		function query($query, $unbuffered = false, $fetchMode = null, ...$fetchModeArgs) {
 			$result = parent::query($query);
 			$this->error = "";
 			if (!$result) {


### PR DESCRIPTION
This PR fixes various new warnings in PHP 8. There are still quite a few remaining, but I'd like to put this up for review already.

After this PR is merged Adminer requires at least PHP 5.6, because of the spread operator in the `query()` method signature.