### PR TITLE
Add optional color for connections

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -2,6 +2,19 @@
 // any method change in this file should be transferred to editor/include/adminer.inc.php and plugins/plugin.php
 
 class Adminer {
+
+	/** Colors for <h2> */
+	static  $KNOWN_COLORS = array(
+		"" => "",
+		"red" => "#cc444b",
+		"orange" => "#f77f00",
+		"yellow" => "#ffe45e",
+		"green" => "#60d394",
+		"blue" => "#79addc",
+		"purple" => "#c287e8",
+		"pink" => "#ff85c8",
+		"grey" => "#cdced3");
+
 	/** @var array operators used in select, null for all operators */
 	var $operators;
 
@@ -124,6 +137,7 @@ class Adminer {
 		echo $this->loginFormField('username', '<tr><th>' . lang('Username') . '<td>', '<input name="auth[username]" id="username" value="' . h($_GET["username"]) . '" autocomplete="username" autocapitalize="off">' . script("focus(qs('#username')); qs('#username').form['auth[driver]'].onchange();"));
 		echo $this->loginFormField('password', '<tr><th>' . lang('Password') . '<td>', '<input type="password" name="auth[password]" autocomplete="current-password">' . "\n");
 		echo $this->loginFormField('db', '<tr><th>' . lang('Database') . '<td>', '<input name="auth[db]" value="' . h($_GET["db"]) . '" autocapitalize="off">' . "\n");
+		echo $this->loginFormField('color', '<tr><th>' . lang('Color') . '<td>', html_select("auth[color]", array_keys(Adminer::$KNOWN_COLORS), $_GET["color"]));
 		echo "</table>\n";
 		echo "<p><input type='submit' value='" . lang('Login') . "'>\n";
 		echo checkbox("auth[permanent]", 1, $_COOKIE["adminer_permanent"], lang('Permanent login')) . "\n";

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -56,6 +56,7 @@ if ($auth) {
 	$username = $auth["username"];
 	$password = (string) $auth["password"];
 	$db = $auth["db"];
+	$color = $auth["color"];
 	set_password($vendor, $server, $username, $password);
 	$_SESSION["db"][$vendor][$server][$username][$db] = true;
 	if ($auth["permanent"]) {
@@ -70,7 +71,7 @@ if ($auth) {
 		|| $_GET["username"] !== $username // "0" == "00"
 		|| DB != $db
 	) {
-		redirect(auth_url($vendor, $server, $username, $db));
+		redirect(auth_url($vendor, $server, $username, $db, $color));
 	}
 	
 } elseif ($_POST["logout"]) {
@@ -79,7 +80,7 @@ if ($auth) {
 		page_footer("db");
 		exit;
 	} else {
-		foreach (array("pwds", "db", "dbs", "queries") as $key) {
+		foreach (array("color", "pwds", "db", "dbs", "queries") as $key) {
 			set_session($key, null);
 		}
 		unset_permanent();
@@ -95,6 +96,10 @@ if ($auth) {
 		set_password($vendor, $server, $username, decrypt_string(base64_decode($cipher), $private));
 		$_SESSION["db"][$vendor][$server][$username][$db] = true;
 	}
+}
+
+if (isset($_GET["color"])) {
+	set_session("color", $_GET["color"]);
 }
 
 function unset_permanent() {

--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -93,7 +93,9 @@ var thousandsSeparator = '<?php echo js_escape(lang(',')); ?>';
 			echo "$title\n";
 		}
 	}
-	echo "<h2>$title_all</h2>\n";
+
+	$color = Adminer::$KNOWN_COLORS[get_session("color")];
+	echo "<h2".(empty($color) ? "" : " style=\"background: $color\"").">$title_all</h2>\n";
 	echo "<div id='ajaxstatus' class='jsonly hidden'></div>\n";
 	restart_session();
 	page_messages($error);

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -197,7 +197,7 @@ function optionlist($options, $selected = null, $use_keys = false) {
 			$opts = $v;
 		}
 		foreach ($opts as $key => $val) {
-			$return .= '<option' . ($use_keys || is_string($key) ? ' value="' . h($key) . '"' : '') . (($use_keys || is_string($key) ? (string) $key : $val) === $selected ? ' selected' : '') . '>' . h($val);
+			$return .= '<option' . ($use_keys || is_string($key) ? ' value="' . h($key) . '"' : '') . (($use_keys || is_string($key) ? (string) $key : $val) === $selected ? ' selected' : '') . '>' . h($val) . '</option>';
 		}
 		if (is_array($v)) {
 			$return .= '</optgroup>';
@@ -599,7 +599,7 @@ function set_session($key, $val) {
 * @param string
 * @return string
 */
-function auth_url($vendor, $server, $username, $db = null) {
+function auth_url($vendor, $server, $username, $db = null, $color = null) {
 	global $drivers;
 	preg_match('~([^?]*)\??(.*)~', remove_from_uri(implode("|", array_keys($drivers)) . "|username|" . ($db !== null ? "db|" : "") . session_name()), $match);
 	return "$match[1]?"
@@ -607,6 +607,7 @@ function auth_url($vendor, $server, $username, $db = null) {
 		. ($vendor != "server" || $server != "" ? urlencode($vendor) . "=" . urlencode($server) . "&" : "")
 		. "username=" . urlencode($username)
 		. ($db != "" ? "&db=" . urlencode($db) : "")
+		. ($color != "" ? "&color=" . urlencode($color) : "")
 		. ($match[2] ? "&$match[2]" : "")
 	;
 }

--- a/adminer/lang/fr.inc.php
+++ b/adminer/lang/fr.inc.php
@@ -288,4 +288,5 @@ $translations = array(
 	'Default value' => 'Valeur par défaut',
 	'If you did not send this request from Adminer then close this page.' => 'Si vous n\'avez pas envoyé cette requête depuis Adminer, alors fermez cette page.',
 	'You are offline.' => 'Vous êtes hors ligne.',
+	'Color' => 'Couleur'
 );


### PR DESCRIPTION
Adminer has become a tool I use very often recently and I have many tabs connected to many databases at the same time.
I wanted to have a way to quickly distinguish databases to avoid manual errors, so I implemented an optional color you can choose at login time (and add to bookmarks `&color=red`), this helps me a lot, maybe this could help others?