### PR TITLE
Make the ME constant pluggable

### DIFF
--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -84,7 +84,11 @@ include "../adminer/drivers/mysql.inc.php"; // must be included as last driver
 
 define("SERVER", $_GET[DRIVER]); // read from pgsql=localhost
 define("DB", $_GET["db"]); // for the sake of speed and size
+if (!defined('MEQPFX')) {
+	define('MEQPFX', '');
+}
 define("ME", str_replace(":", "%3a", preg_replace('~\?.*~', '', relative_uri())) . '?'
+	. MEQPFX
 	. (sid() ? SID . '&' : '')
 	. (SERVER !== null ? DRIVER . "=" . urlencode(SERVER) . '&' : '')
 	. (isset($_GET["username"]) ? "username=" . urlencode($_GET["username"]) . '&' : '')


### PR DESCRIPTION
When creating an integration of Adminer as a third party service, in a similar manner to PHPMyAdmin, query string parameters used for selection/authentication are destroyed. This hinders the ability to integrate Adminer when robust, non-rewritten URLs are used.

For example, I try to make Adminer accessible at `https://example.com/admin-ui/3rd-party.php?3ptask=adminer&3ptoken=abc123` but all generated URLs will have those parameters removed like so `https://example.com/admin-ui/3rd-party.php?file=default.css&version=x.y.z` which would cause failure.

This constant enables preservation of parameters via a simple define:

```php
define('MEQPFX', '3ptask=adminer&3ptoken=' . rawurlencode($_GET['3ptoken']) . '&');
```