### PR TITLE
Fix MongoDB connect 'Database does not support password.' tips

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -194,6 +194,10 @@ if (isset($_GET["mongo"])) {
 			return $connection->_db->selectCollection($_GET["select"])->count($where);
 		}
 
+        function ping($link) {
+            return true;
+        }
+
 		$operators = array("=");
 
 	} elseif (class_exists('MongoDB\Driver\Manager')) {
@@ -220,7 +224,6 @@ if (isset($_GET["mongo"])) {
 			function quote($string) {
 				return $string;
 			}
-
 		}
 
 		class Min_Result {
@@ -539,6 +542,12 @@ if (isset($_GET["mongo"])) {
 			return $data;
 		}
 
+        function ping($link) {
+            $class = 'MongoDB\Driver\Command';
+            $link->executeCommand('admin',new $class(['ping' => 1]));
+            return true;
+        }
+
 		$operators = array(
 			"=",
 			"!=",
@@ -626,7 +635,7 @@ if (isset($_GET["mongo"])) {
 			if ($password != "") {
 				$options["password"] = "";
 				try {
-					$connection->connect("mongodb://$server", $options);
+					ping($connection->connect("mongodb://$server", $options));
 					return lang('Database does not support password.');
 				} catch (Exception $ex) {
 					// this is what we want


### PR DESCRIPTION
Add MongoDB Drivers func ping.

According to the official document: [MongoDB\Driver\Manager::__construct](https://www.php.net/manual/en/mongodb-driver-manager.construct.php)

> Note: Per the » Server Discovery and Monitoring Specification, this constructor performs no I/O. Connections will be initialized on demand, when the first operation is executed.

After creating the object, perform any operation to generate I/O connection to verify that the password is correct.

Do not add `ping` validation to the correct password section to reduce changes to unknown code.

> Code reference from [document Example #1](https://www.php.net/manual/en/mongodb-driver-manager.executecommand.php#refsect1-mongodb-driver-manager.executecommand-examples)