### PR TITLE
Travis: add php 7.4 and 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 script: git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.php$' | xargs -n1 -P8 php -l | grep -v 'No syntax errors'; test $? -eq 1


### PR DESCRIPTION
This PR adds PHP 7.4 and 8.0 to Travis CI.