### PR TITLE
Delay adminer object init to after constants have been set.

### DIFF
--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -83,7 +83,6 @@ include "../adminer/drivers/mssql.inc.php";
 include "../adminer/drivers/mongo.inc.php";
 include "../adminer/drivers/elastic.inc.php";
 include "./include/adminer.inc.php";
-$adminer = (function_exists('adminer_object') ? adminer_object() : new Adminer);
 include "../adminer/drivers/mysql.inc.php"; // must be included as last driver
 
 $config = driver_config();
@@ -96,9 +95,6 @@ $operators = $config['operators'];
 $functions = $config['functions'];
 $grouping = $config['grouping'];
 $edit_functions = $config['edit_functions'];
-if ($adminer->operators === null) {
-	$adminer->operators = $operators;
-}
 
 define("SERVER", $_GET[DRIVER]); // read from pgsql=localhost
 define("DB", $_GET["db"]); // for the sake of speed and size
@@ -108,6 +104,11 @@ define("ME", preg_replace('~\?.*~', '', relative_uri()) . '?'
 	. (isset($_GET["username"]) ? "username=" . urlencode($_GET["username"]) . '&' : '')
 	. (DB != "" ? 'db=' . urlencode(DB) . '&' . (isset($_GET["ns"]) ? "ns=" . urlencode($_GET["ns"]) . "&" : "") : '')
 );
+
+$adminer = (function_exists('adminer_object') ? adminer_object() : new Adminer);
+if ($adminer->operators === null) {
+	$adminer->operators = $operators;
+}
 
 include "../adminer/include/version.inc.php";
 include "../adminer/include/design.inc.php";


### PR DESCRIPTION
The update to 4.8.0 includes 4742bde873598e3017c566777b37e281996514b5, which causes `adminer_object` to be called before the MySQL driver is initialized and before any of the Adminer constants have been initialized. This can cause external plugin code to fail if it relies on these constants in order to set up things before Adminer takes any authentication-related actions (e. g. via a plugin-provided constructor function).

This PR changes the order to be more compatible and allow these plugins to continue to work.

NOTE: I am currently marking this as draft as I still have to verify whether this is enough to fix the issue without introducing negative side effects.