### PR TITLE
Use ST_SRID() in mysql driver for MySQL 8

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -1099,7 +1099,8 @@ if (!defined("DRIVER")) {
 			$return = "CONV($return, 2, 10) + 0";
 		}
 		if (preg_match("~geometry|point|linestring|polygon~", $field["type"])) {
-			$return = (min_version(8) ? "ST_" : "") . "GeomFromText($return, SRID($field[field]))";
+			$prefix = (min_version(8) ? "ST_" : "");
+			$return = "${prefix}GeomFromText($return, ${prefix}SRID($field[field]))";
 		}
 		return $return;
 	}

--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -1100,7 +1100,13 @@ if (!defined("DRIVER")) {
 		}
 		if (preg_match("~geometry|point|linestring|polygon~", $field["type"])) {
 			$prefix = (min_version(8) ? "ST_" : "");
-			$return = "${prefix}GeomFromText($return, ${prefix}SRID($field[field]))";
+			$return = sprintf(
+				'%sGeomFromText(%s, %sSRID(%s))',
+				$prefix,
+				$return,
+				$prefix,
+				$field['field']
+			);
 		}
 		return $return;
 	}

--- a/changes.txt
+++ b/changes.txt
@@ -7,6 +7,7 @@ PostgreSQL: Support UPDATE OF triggers (bug #789)
 PostgreSQL: Support triggers with more events (OR)
 PostgreSQL < 10 PDO: Avoid displaying GENERATED ALWAYS BY IDENTITY everywhere (bug #785, regression from 4.7.9)
 SQLite: Fix displayed types (bug #784, regression from 4.8.0)
+MySQL: Use ST_SRID() instead of SRID() for MySQL 8 (PR #418)
 
 Adminer 4.8.0 (released 2021-02-10):
 Support function default values in insert (bug #713)


### PR DESCRIPTION
`SRID()` is no longer available in MySQL 8 and has been replaced with `ST_SRID`.

This is a follow-up to: https://github.com/vrana/adminer/commit/327041874ecdb398436adc8a5d32d49c6866dd8c