### PR TITLE
Field privileges 'where' and 'order'

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -367,7 +367,12 @@ if (isset($_GET["elastic"])) {
 					"field" => $name,
 					"full_type" => $field["type"],
 					"type" => $field["type"],
-					"privileges" => array("insert" => 1, "select" => 1, "update" => 1),
+					"privileges" => array(
+						"insert" => 1,
+						"select" => 1,
+						"update" => 1,
+						"where" => !isset($field["index"]) || $field["index"] ?: null,
+					),
 				);
 				if ($field["properties"]) { // only leaf fields can be edited
 					unset($return[$name]["privileges"]["insert"]);

--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -372,6 +372,7 @@ if (isset($_GET["elastic"])) {
 						"select" => 1,
 						"update" => 1,
 						"where" => !isset($field["index"]) || $field["index"] ?: null,
+						"order" => $field["type"] != "text" ?: null
 					),
 				);
 				if ($field["properties"]) { // only leaf fields can be edited

--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -463,6 +463,7 @@ if (isset($_GET["mongo"])) {
 									"insert" => 1,
 									"select" => 1,
 									"update" => 1,
+									"where" => 1,
 								),
 							);
 						}

--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -464,6 +464,7 @@ if (isset($_GET["mongo"])) {
 									"select" => 1,
 									"update" => 1,
 									"where" => 1,
+									"order" => 1,
 								),
 							);
 						}

--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -387,7 +387,7 @@ WHERE o.schema_id = SCHEMA_ID(" . q(get_schema()) . ") AND o.type IN ('S', 'U', 
 				"null" => $row["is_nullable"],
 				"auto_increment" => $row["is_identity"],
 				"collation" => $row["collation_name"],
-				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1),
+				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1, "order" => 1),
 				"primary" => $row["is_identity"], //! or indexes.is_primary_key
 				"comment" => $comments[$row["name"]],
 			);

--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -387,7 +387,7 @@ WHERE o.schema_id = SCHEMA_ID(" . q(get_schema()) . ") AND o.type IN ('S', 'U', 
 				"null" => $row["is_nullable"],
 				"auto_increment" => $row["is_identity"],
 				"collation" => $row["collation_name"],
-				"privileges" => array("insert" => 1, "select" => 1, "update" => 1),
+				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1),
 				"primary" => $row["is_identity"], //! or indexes.is_primary_key
 				"comment" => $comments[$row["name"]],
 			);

--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -551,7 +551,7 @@ if (!defined("DRIVER")) {
 				"auto_increment" => ($row["Extra"] == "auto_increment"),
 				"on_update" => (preg_match('~^on update (.+)~i', $row["Extra"], $match) ? $match[1] : ""), //! available since MySQL 5.1.23
 				"collation" => $row["Collation"],
-				"privileges" => array_flip(preg_split('~, *~', $row["Privileges"])) + ["where" => 1],
+				"privileges" => array_flip(preg_split('~, *~', $row["Privileges"])) + ["where" => 1, "order" => 1],
 				"comment" => $row["Comment"],
 				"primary" => ($row["Key"] == "PRI"),
 				// https://mariadb.com/kb/en/library/show-columns/, https://github.com/vrana/adminer/pull/359#pullrequestreview-276677186

--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -551,7 +551,7 @@ if (!defined("DRIVER")) {
 				"auto_increment" => ($row["Extra"] == "auto_increment"),
 				"on_update" => (preg_match('~^on update (.+)~i', $row["Extra"], $match) ? $match[1] : ""), //! available since MySQL 5.1.23
 				"collation" => $row["Collation"],
-				"privileges" => array_flip(preg_split('~, *~', $row["Privileges"])),
+				"privileges" => array_flip(preg_split('~, *~', $row["Privileges"])) + ["where" => 1],
 				"comment" => $row["Comment"],
 				"primary" => ($row["Key"] == "PRI"),
 				// https://mariadb.com/kb/en/library/show-columns/, https://github.com/vrana/adminer/pull/359#pullrequestreview-276677186

--- a/adminer/drivers/oracle.inc.php
+++ b/adminer/drivers/oracle.inc.php
@@ -297,7 +297,7 @@ ORDER BY 1"
 				"null" => ($row["NULLABLE"] == "Y"),
 				//! "auto_increment" => false,
 				//! "collation" => $row["CHARACTER_SET_NAME"],
-				"privileges" => array("insert" => 1, "select" => 1, "update" => 1),
+				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1),
 				//! "comment" => $row["Comment"],
 				//! "primary" => ($row["Key"] == "PRI"),
 			);

--- a/adminer/drivers/oracle.inc.php
+++ b/adminer/drivers/oracle.inc.php
@@ -297,7 +297,7 @@ ORDER BY 1"
 				"null" => ($row["NULLABLE"] == "Y"),
 				//! "auto_increment" => false,
 				//! "collation" => $row["CHARACTER_SET_NAME"],
-				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1),
+				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1, "order" => 1),
 				//! "comment" => $row["Comment"],
 				//! "primary" => ($row["Key"] == "PRI"),
 			);

--- a/adminer/drivers/sqlite.inc.php
+++ b/adminer/drivers/sqlite.inc.php
@@ -321,7 +321,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 				"full_type" => $type,
 				"default" => (preg_match("~'(.*)'~", $default, $match) ? str_replace("''", "'", $match[1]) : ($default == "NULL" ? null : $default)),
 				"null" => !$row["notnull"],
-				"privileges" => array("select" => 1, "insert" => 1, "update" => 1, "where" => 1),
+				"privileges" => array("select" => 1, "insert" => 1, "update" => 1, "where" => 1, "order" => 1),
 				"primary" => $row["pk"],
 			);
 			if ($row["pk"]) {

--- a/adminer/drivers/sqlite.inc.php
+++ b/adminer/drivers/sqlite.inc.php
@@ -321,7 +321,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 				"full_type" => $type,
 				"default" => (preg_match("~'(.*)'~", $default, $match) ? str_replace("''", "'", $match[1]) : ($default == "NULL" ? null : $default)),
 				"null" => !$row["notnull"],
-				"privileges" => array("select" => 1, "insert" => 1, "update" => 1),
+				"privileges" => array("select" => 1, "insert" => 1, "update" => 1, "where" => 1),
 				"primary" => $row["pk"],
 			);
 			if ($row["pk"]) {

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -561,7 +561,8 @@ class Adminer {
 					// find anywhere
 					$cols = array();
 					foreach ($fields as $name => $field) {
-						if ((preg_match('~^[-\d.' . (preg_match('~IN$~', $val["op"]) ? ',' : '') . ']+$~', $val["val"]) || !preg_match('~' . number_type() . '|bit~', $field["type"]))
+						if (isset($field["privileges"]["where"])
+                            && (preg_match('~^[-\d.' . (preg_match('~IN$~', $val["op"]) ? ',' : '') . ']+$~', $val["val"]) || !preg_match('~' . number_type() . '|bit~', $field["type"]))
 							&& (!preg_match("~[\x80-\xFF]~", $val["val"]) || preg_match('~char|text|enum|set~', $field["type"]))
 							&& (!preg_match('~date|timestamp~', $field["type"]) || preg_match('~^\d+-\d+-\d+~', $val["val"]))
 						) {

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -1077,7 +1077,7 @@ function fields_from_edit() {
 		$name = bracket_escape($key, 1); // 1 - back
 		$return[$name] = array(
 			"field" => $name,
-			"privileges" => array("insert" => 1, "update" => 1, "where" => 1),
+			"privileges" => array("insert" => 1, "update" => 1, "where" => 1, "order" => 1),
 			"null" => 1,
 			"auto_increment" => ($key == $driver->primary),
 		);

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -1077,7 +1077,7 @@ function fields_from_edit() {
 		$name = bracket_escape($key, 1); // 1 - back
 		$return[$name] = array(
 			"field" => $name,
-			"privileges" => array("insert" => 1, "update" => 1),
+			"privileges" => array("insert" => 1, "update" => 1, "where" => 1),
 			"null" => 1,
 			"auto_increment" => ($key == $driver->primary),
 		);

--- a/adminer/select.inc.php
+++ b/adminer/select.inc.php
@@ -9,6 +9,7 @@ parse_str($_COOKIE["adminer_import"], $adminer_import);
 
 $rights = array(); // privilege => 0
 $columns = array(); // selectable columns
+$search_columns = array(); // searchable columns
 $text_length = null;
 foreach ($fields as $key => $field) {
 	$name = $adminer->fieldName($field);
@@ -17,6 +18,9 @@ foreach ($fields as $key => $field) {
 		if (is_shortable($field)) {
 			$text_length = $adminer->selectLengthProcess();
 		}
+	}
+	if (isset($field["privileges"]["where"]) && $name != "") {
+		$search_columns[$key] = html_entity_decode(strip_tags($name), ENT_QUOTES);
 	}
 	$rights += $field["privileges"];
 }
@@ -245,7 +249,7 @@ if (!$columns && support("table")) {
 	echo '<input type="hidden" name="select" value="' . h($TABLE) . '">';
 	echo "</div>\n";
 	$adminer->selectColumnsPrint($select, $columns);
-	$adminer->selectSearchPrint($where, $columns, $indexes);
+	$adminer->selectSearchPrint($where, $search_columns, $indexes);
 	$adminer->selectOrderPrint($order, $columns, $indexes);
 	$adminer->selectLimitPrint($limit);
 	$adminer->selectLengthPrint($text_length);
@@ -336,7 +340,7 @@ if (!$columns && support("table")) {
 						echo apply_sql_function($val["fun"], $name) . "</a>"; //! columns looking like functions
 						echo "<span class='column hidden'>";
 						echo "<a href='" . h($href . $desc) . "' title='" . lang('descending') . "' class='text'> ↓</a>";
-						if (!$val["fun"]) {
+						if (!$val["fun"] && isset($field["privileges"]["where"])) {
 							echo '<a href="#fieldset-search" title="' . lang('Search') . '" class="text jsonly"> =</a>';
 							echo script("qsl('a').onclick = partial(selectSearch, '" . js_escape($key) . "');");
 						}

--- a/adminer/select.inc.php
+++ b/adminer/select.inc.php
@@ -10,6 +10,7 @@ parse_str($_COOKIE["adminer_import"], $adminer_import);
 $rights = array(); // privilege => 0
 $columns = array(); // selectable columns
 $search_columns = array(); // searchable columns
+$order_columns = array(); // searchable columns
 $text_length = null;
 foreach ($fields as $key => $field) {
 	$name = $adminer->fieldName($field);
@@ -21,6 +22,9 @@ foreach ($fields as $key => $field) {
 	}
 	if (isset($field["privileges"]["where"]) && $name != "") {
 		$search_columns[$key] = html_entity_decode(strip_tags($name), ENT_QUOTES);
+	}
+	if (isset($field["privileges"]["order"]) && $name != "") {
+		$order_columns[$key] = html_entity_decode(strip_tags($name), ENT_QUOTES);
 	}
 	$rights += $field["privileges"];
 }
@@ -250,7 +254,7 @@ if (!$columns && support("table")) {
 	echo "</div>\n";
 	$adminer->selectColumnsPrint($select, $columns);
 	$adminer->selectSearchPrint($where, $search_columns, $indexes);
-	$adminer->selectOrderPrint($order, $columns, $indexes);
+	$adminer->selectOrderPrint($order, $order_columns, $indexes);
 	$adminer->selectLimitPrint($limit);
 	$adminer->selectLengthPrint($text_length);
 	$adminer->selectActionPrint($indexes);
@@ -335,11 +339,19 @@ if (!$columns && support("table")) {
 						$column = idf_escape($key);
 						$href = remove_from_uri('(order|desc)[^=]*|page') . '&order%5B0%5D=' . urlencode($key);
 						$desc = "&desc%5B0%5D=1";
+						$sortable = isset($field["privileges"]["order"]);
 						echo "<th id='th[" . h(bracket_escape($key)) . "]'>" . script("mixin(qsl('th'), {onmouseover: partial(columnMouse), onmouseout: partial(columnMouse, ' hidden')});", "");
-						echo '<a href="' . h($href . ($order[0] == $column || $order[0] == $key || (!$order && $is_group && $group[0] == $column) ? $desc : '')) . '">'; // $order[0] == $key - COUNT(*)
-						echo apply_sql_function($val["fun"], $name) . "</a>"; //! columns looking like functions
+						if ($sortable) {
+							echo '<a href="' . h($href . ($order[0] == $column || $order[0] == $key || (!$order && $is_group && $group[0] == $column) ? $desc : '')) . '">'; // $order[0] == $key - COUNT(*)
+						}
+						echo apply_sql_function($val["fun"], $name); //! columns looking like functions
+						if ($sortable) {
+							echo "</a>";
+						}
 						echo "<span class='column hidden'>";
-						echo "<a href='" . h($href . $desc) . "' title='" . lang('descending') . "' class='text'> ↓</a>";
+						if ($sortable) {
+							echo "<a href='" . h($href . $desc) . "' title='" . lang('descending') . "' class='text'> ↓</a>";
+						}
 						if (!$val["fun"] && isset($field["privileges"]["where"])) {
 							echo '<a href="#fieldset-search" title="' . lang('Search') . '" class="text jsonly"> =</a>';
 							echo script("qsl('a').onclick = partial(selectSearch, '" . js_escape($key) . "');");

--- a/plugins/drivers/clickhouse.php
+++ b/plugins/drivers/clickhouse.php
@@ -316,7 +316,7 @@ if (isset($_GET["clickhouse"])) {
 				"default" => trim($row['default_expression']),
 				"null" => $nullable,
 				"auto_increment" => '0',
-				"privileges" => array("insert" => 1, "select" => 1, "update" => 0),
+				"privileges" => array("insert" => 1, "select" => 1, "update" => 0, "where" => 1),
 			);
 		}
 

--- a/plugins/drivers/clickhouse.php
+++ b/plugins/drivers/clickhouse.php
@@ -316,7 +316,7 @@ if (isset($_GET["clickhouse"])) {
 				"default" => trim($row['default_expression']),
 				"null" => $nullable,
 				"auto_increment" => '0',
-				"privileges" => array("insert" => 1, "select" => 1, "update" => 0, "where" => 1),
+				"privileges" => array("insert" => 1, "select" => 1, "update" => 0, "where" => 1, "order" => 1),
 			);
 		}
 

--- a/plugins/drivers/firebird.php
+++ b/plugins/drivers/firebird.php
@@ -250,7 +250,7 @@ ORDER BY r.RDB$FIELD_POSITION';
 				"null" => (trim($row["FIELD_NOT_NULL_CONSTRAINT"]) == "YES"),
 				"auto_increment" => '0',
 				"collation" => trim($row["FIELD_COLLATION"]),
-				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1),
+				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1, "order" => 1),
 				"comment" => trim($row["FIELD_DESCRIPTION"]),
 			);
 		}

--- a/plugins/drivers/firebird.php
+++ b/plugins/drivers/firebird.php
@@ -250,7 +250,7 @@ ORDER BY r.RDB$FIELD_POSITION';
 				"null" => (trim($row["FIELD_NOT_NULL_CONSTRAINT"]) == "YES"),
 				"auto_increment" => '0',
 				"collation" => trim($row["FIELD_COLLATION"]),
-				"privileges" => array("insert" => 1, "select" => 1, "update" => 1),
+				"privileges" => array("insert" => 1, "select" => 1, "update" => 1, "where" => 1),
 				"comment" => trim($row["FIELD_DESCRIPTION"]),
 			);
 		}


### PR DESCRIPTION
In Elasticsearch, not all fields are searchable and sortable. It is essential to use only allowed fields in search query. Searching produce errors otherwise.