### PR TITLE
add ability to pass sslmode for postgres

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -20,6 +20,10 @@ if (isset($_GET["pgsql"])) {
 				$db = $adminer->database();
 				set_error_handler(array($this, '_error'));
 				$this->_string = "host='" . str_replace(":", "' port='", addcslashes($server, "'\\")) . "' user='" . addcslashes($username, "'\\") . "' password='" . addcslashes($password, "'\\") . "'";
+				$ssl = $adminer->connectSsl();
+				if ($ssl) {
+					$this->_string.= " sslmode='" . ($ssl['sslmode'] ?: 'require') . "'";
+				}
 				$this->_link = @pg_connect("$this->_string dbname='" . ($db != "" ? addcslashes($db, "'\\") : "postgres") . "'", PGSQL_CONNECT_FORCE_NEW);
 				if (!$this->_link && $db != "") {
 					// try to connect directly with database for performance


### PR DESCRIPTION
add ability to force the ssl mode by adding the config for the login-ssl plugin

```php
<?php
require_once('plugins/login-ssl.php');

return new AdminerLoginSsl([
  "sslmode" => "require",
]);
```