### PR TITLE
Avoid Warning of PHP 8 on unknown properties (bug #801)

### DIFF
--- a/adminer/include/editing.inc.php
+++ b/adminer/include/editing.inc.php
@@ -20,8 +20,14 @@ function select($result, $connection2 = null, $orgtables = array(), $limit = 0) 
 			echo "<div class='scrollable'>\n";
 			echo "<table cellspacing='0' class='nowrap'>\n";
 			echo "<thead><tr>";
+			$fieldproperties=['name','orgtable','orgname','table','charsetnr','type'];
 			for ($j=0; $j < count($row); $j++) {
 				$field = $result->fetch_field();
+				foreach ($fieldproperties as $fieldproperty) {
+                    			if(!isset($field->$fieldproperty)) {
+                        			$field->$fieldproperty = null;
+                    			}
+                		}
 				$name = $field->name;
 				$orgtable = $field->orgtable;
 				$orgname = $field->orgname;


### PR DESCRIPTION
### Avoid Warning of PHP 8 on unknown properties on the `$field` object in function `select()`

@hemroy21 has open an issue on my "adminer sqlite repository":

- FrancoisCapon/LoginToASqlite3DatabaseWithoutCredentialsWithAdminer/issues/3

and on SourceForge:

- [#801 Undefined property: stdClass::$orgtable warning in adminer 4.8.1 ](https://sourceforge.net/p/adminer/bugs-and-features/801/)

We made some tests and the conclusion is that the issue is not specific to `sqlite` but only to `PHP 8.0` (Warning vs Notice).

```php
<?php
highlight_file(__FILE__);
echo '<p>'.PHP_VERSION.'</p>';
$object = (object) array ();
var_dump($object);
var_dump($object->property);

7.4.15

object(stdClass)#1 (0) { }
Notice: Undefined property: stdClass::$property in ... on line 6
NULL

8.0.2

object(stdClass)#1 (0) { }
Warning: Undefined property: stdClass::$property in ... on line 6
NULL
```

-  **Therefore, each unknown property must be set with PHP 8.0 to avoid warnings.**
