### PR TITLE
PostgreSQL: exclude internal schemas from listing

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -710,7 +710,7 @@ AND typelem = 0"
 	}
 
 	function schemas() {
-		return get_vals("SELECT nspname FROM pg_namespace ORDER BY nspname");
+		return get_vals("SELECT nspname FROM pg_namespace WHERE nspname NOT LIKE 'pg_temp_%' AND nspname NOT LIKE 'pg_toast_temp_%' ORDER BY nspname");
 	}
 
 	function get_schema() {


### PR DESCRIPTION
pg_temp_% and pg_toast_temp_% are postgres-internal schemas for temporary tables and there is no reason why a normal user would need to access them. This PR declutters the list of schemas by hiding them.