### PR TITLE
Fix elasticsearch(>=7.11) does not support body in GET request

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -16,12 +16,17 @@ if (isset($_GET["elastic"])) {
 			 */
 			function rootQuery($path, $content = array(), $method = 'GET') {
 				@ini_set('track_errors', 1); // @ - may be disabled
-				$file = @file_get_contents("$this->_url/" . ltrim($path, '/'), false, stream_context_create(array('http' => array(
+				$opts = array( 'http'=>array(
 					'method' => $method,
-					'content' => $content === null ? $content : json_encode($content),
-					'header' => 'Content-Type: application/json',
 					'ignore_errors' => 1, // available since PHP 5.2.10
-				))));
+					));
+				if ($method != 'GET') {
+					$opts['http']['content'] = $content === null ? $content : json_encode($content);
+					$opts['http']['header'] = 'Content-Type: application/json';
+				}
+				$context = stream_context_create($opts);
+				$file = @file_get_contents("$this->_url/" . ltrim($path, '/'), false, $context);
+
 				if (!$file) {
 					$this->error = $php_errormsg;
 					return $file;


### PR DESCRIPTION
Elasticsearch(>=7.11) does not support the body in GET request and returns an error message when making GET request with body such as the login request, For more details read this [elasticsearch issue](https://github.com/elastic/elasticsearch/issues/69532) and the pull request that introduced this change [66043](https://github.com/elastic/elasticsearch/pull/66043).

To fix this I made changes in the `rootQuery` function of elasticsearch driver to only send the request body and content-type header if the request method is not `GET`.

Fix tested on:
* Elasticsearch Version: 7.14.0
* Elasticsearch Version: 7.7.0

