### PR TITLE
Fix warning `$sql` not exists

### DIFF
--- a/adminer/script.inc.php
+++ b/adminer/script.inc.php
@@ -12,7 +12,7 @@ if ($_GET["script"] == "db") {
 			foreach ($sums + array("Auto_increment" => 0, "Rows" => 0) as $key => $val) {
 				if ($table_status[$key] != "") {
 					$val = format_number($table_status[$key]);
-					json_row("$key-$name", ($key == "Rows" && $val && $table_status["Engine"] == ($sql == "pgsql" ? "table" : "InnoDB")
+					json_row("$key-$name", ($key == "Rows" && $val && $table_status["Engine"] == ($jush == "pgsql" ? "table" : "InnoDB")
 						? "~ $val"
 						: $val
 					));


### PR DESCRIPTION
As using php8+, call to undefined var will cause warning output, which cause mysql innodb table not shown table info(shown `?` instead of real data).

```
Mysql: MySQL version: 8.0.26 through PHP extension PDO_MySQL
PHP: 8.0.11
```