### PR TITLE
Prevention of the warning caused by an access to an undefined property (php8)

### DIFF
--- a/adminer/include/editing.inc.php
+++ b/adminer/include/editing.inc.php
@@ -49,7 +49,7 @@ function select($result, $connection2 = null, $orgtables = array(), $limit = 0) 
 				if ($field->charsetnr == 63) { // 63 - binary
 					$blobs[$j] = true;
 				}
-				$types[$j] = $field->type;
+				$types[$j] = isset($field->type) ? $field->type : null;
 				echo "<th" . ($orgtable != "" || $field->name != $orgname ? " title='" . h(($orgtable != "" ? "$orgtable." : "") . $orgname) . "'" : "") . ">" . h($name)
 					. ($orgtables ? doc_link(array(
 						'sql' => "explain-output.html#explain_" . strtolower($name),


### PR DESCRIPTION
Access to an undefined property was a _notice_ in php 7.4, but was changed to a _warning_ in php 8. And as the Adminer is "hiding" only notices, this warning has started to appear while submitting custom queries:

<img width="860" alt="Screenshot 2021-09-27 at 20 20 12" src="https://user-images.githubusercontent.com/49492371/135000338-66b9299b-8905-4cea-82fa-13373ee12cf6.png">

 