### PR TITLE
mysqli_real_connect: set connection flag

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -27,7 +27,7 @@ if (!defined("DRIVER")) {
 					$database,
 					(is_numeric($port) ? $port : ini_get("mysqli.default_port")),
 					(!is_numeric($port) ? $port : $socket),
-					($ssl ? 64 : 0) // 64 - MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT (not available before PHP 5.6.16)
+					($ssl?$ssl['cflags'] ?? 64 : 0) // 64 - MYSQLI_CLIENT_SSL (not available before PHP 5.6.16)
 				);
 				$this->options(MYSQLI_OPT_LOCAL_INFILE, false);
 				return $return;


### PR DESCRIPTION
In my use case I have to connect to some MySQL services only available through a SSL connection but without a way to get their CA to trust.

I did not find any other way to fix the error:

> Connections using insecure transport are prohibited while --require_secure_transport=ON.

Than changing the [`mysqli_real_connect`](https://www.php.net/mysqli.real-connect#refsect1-mysqli.real-connect-parameters) connection flags from `64` (`MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT`) to `2048` (`MYSQLI_CLIENT_SSL`), i.e.:

```php
<?php
function adminer_object() {
	include_once "./plugins/plugin.php";
	$adminer = new AdminerPlugin(Array());
	foreach (glob("plugins/*.php") as $filename) include_once "./$filename";
	$adminer->plugins = Array(
		new AdminerLoginSsl(Array("key"=>NULL, "cert"=>NULL, "ca"=>NULL, "cflags"=>MYSQLI_CLIENT_SSL)),
		// ...
	);
	return $adminer;
}
include "./adminer.php";
```

Any thoughts on this problem and other possibles workarounds?

**Warning:** this patch use the PHP 7 [Null Coalesce Operator](https://wiki.php.net/rfc/isset_ternary) syntax.