### PR TITLE
Remove quote from $sequence_name

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -783,7 +783,7 @@ AND typelem = 0"
 			if (preg_match('~nextval\(\'([^\']+)\'\)~', $field['default'], $matches)) {
 				$sequence_name = $matches[1];
 				$sq = reset(get_rows(min_version(10)
-					? "SELECT *, cache_size AS cache_value FROM pg_sequences WHERE schemaname = current_schema() AND sequencename = " . q($sequence_name)
+					? "SELECT *, cache_size AS cache_value FROM pg_sequences WHERE schemaname = current_schema() AND sequencename = " . q(preg_replace('/^"(.+)"$/', "$1", $sequence_name))
 					: "SELECT * FROM $sequence_name"
 				));
 				$sequences[] = ($style == "DROP+CREATE" ? "DROP SEQUENCE IF EXISTS $sequence_name;\n" : "")


### PR DESCRIPTION
Location: `adminer/drivers/pgsql.inc.php:786`

When `$sequence_name` has double quote around like `""google-drive_account_id_seq""` then the SQL query is like this:
```sql
SELECT *, cache_size AS cache_value FROM pg_sequences WHERE schemaname = current_schema() AND sequencename = '"google-drive_account_id_seq"'
```

The result of the query above return false. And when trying to import SQL file:
```
Error in query: ERROR: syntax error at or near "MINVALUE"
LINE 1: ...SEQUENCE "google-drive_account_id_seq" INCREMENT MINVALUE ...
```

The query cause error:
```
CREATE SEQUENCE "google-drive_account_id_seq" INCREMENT  MINVALUE  MAXVALUE  CACHE ;
```

The correct query should be:
```sql
SELECT *, cache_size AS cache_value FROM pg_sequences WHERE schemaname = current_schema() AND sequencename = 'google-drive_account_id_seq'
```