### PR TITLE
When editing turn URLs into clickable links

### DIFF
--- a/adminer/include/editing.inc.php
+++ b/adminer/include/editing.inc.php
@@ -88,6 +88,9 @@ function select($result, $connection2 = null, $orgtables = array(), $limit = 0) 
 			if ($link) {
 				$val = "<a href='" . h($link) . "'" . (is_url($link) ? target_blank() : '') . ">$val</a>";
 			}
+			elseif (is_url($val)) {
+				$val = "<a href='" . h($val) . "'" . target_blank() .">$val</a>";
+			}
 			echo "<td>$val";
 		}
 	}


### PR DESCRIPTION
Maybe there's a reason this isn't being done but one of our users requested that the output of stored procedures should produce clickable links.