### PR TITLE
MySQL PDO Add possibility to disable verification of the server SSL certificate.

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -246,6 +246,9 @@ if (!defined("DRIVER")) {
 					if (!empty($ssl['ca'])) {
 						$options[PDO::MYSQL_ATTR_SSL_CA] = $ssl['ca'];
 					}
+					if (!empty($ssl['verify'])) {
+						$options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = $ssl['verify'];
+					}
 				}
 				$this->dsn(
 					"mysql:charset=utf8;host=" . str_replace(":", ";unix_socket=", preg_replace('~:(\d)~', ';port=\1', $server)),

--- a/plugins/login-ssl.php
+++ b/plugins/login-ssl.php
@@ -11,7 +11,7 @@ class AdminerLoginSsl {
 	var $ssl;
 	
 	/** 
-	* @param array array("key" => filename, "cert" => filename, "ca" => filename)
+	* @param array array("key" => filename, "cert" => filename, "ca" => filename, "verify" => true | false)
 	*/
 	function __construct($ssl) {
 		$this->ssl = $ssl;


### PR DESCRIPTION
While using explicitly `mysqli` as driver the server certificate verification is switched to false by default, using Standard driver `PDO` it can't be disabled. There are some use-cases making that the only way to use TLS (e.g. running with Self-Signed Certificates in Docker).
No PHP-Skills, so please check :)