### PR TITLE
GitHub disabled `git://` on January 11, 2022

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "jush"]
 	path = externals/jush
-	url = git://github.com/vrana/jush
+	url = https://github.com/vrana/jush
 [submodule "JsShrink"]
 	path = externals/JsShrink
-	url = git://github.com/vrana/JsShrink
+	url = https://github.com/vrana/JsShrink
 [submodule "designs/hydra"]
 	path = designs/hydra
 	url = https://github.com/Niyko/Hydra-Dark-Theme-for-Adminer


### PR DESCRIPTION
## GitHub disabled `git://` on January 11, 2022

* https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

```
W:\>git clone --recurse-submodules https://github.com/vrana/adminer.git
...
Cloning into 'W:/adminer/externals/JsShrink'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=No error

fatal: clone of 'git://github.com/vrana/JsShrink' into submodule path 'W:/adminer/externals/JsShrink' failed
Failed to clone 'externals/JsShrink'. Retry scheduled
Cloning into 'W:/adminer/externals/jush'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=No error
...
```

```
W:\>git clone --branch patch-1 --recurse-submodules https://github.com/FrancoisCapon/adminer.git
...
Cloning into 'W:/adminer/externals/JsShrink'...
...
Cloning into 'W:/adminer/externals/jush'...
...
Submodule path 'externals/JsShrink': checked out '17cbfacae67dede6d94d94ce92214c8ca31d858e'
Submodule path 'externals/jush': checked out 'ae33623c66189375a3654954cddc1c73f65c36fa'
```
