### PR TITLE
Replace for PHP tmpfile function

### DIFF
--- a/adminer/include/tmpfile.inc.php
+++ b/adminer/include/tmpfile.inc.php
@@ -5,7 +5,15 @@ class TmpFile {
 	var $size;
 	
 	function __construct() {
-		$this->handler = tmpfile();
+		if (function_exists('tmpfile'))
+			$this->handler = tmpfile();
+		else {
+			$temp_file_template = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+			$temp_file='';
+			for($i=0;$i<20;$i++)
+				$temp_file .= $temp_file_template[rand(0,strlen($temp_file_template)-1)];
+			$this->handler = fopen($temp_file, "w+");	
+		}
 	}
 	
 	function write($contents) {


### PR DESCRIPTION
Some shared hostings doesn't allow to use the tmpfile() PHP functions (i.e. when this function is disabled via  disable_functions  in the php.ini), so Adminer stop working in that servers.  This change create a random name for a temporary file that use the standard fopen function.