### PR TITLE
Updates pepa-linha submodule to include latest changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/Niyko/Hydra-Dark-Theme-for-Adminer
 [submodule "designs/pepa-linha-dark"]
 	path = designs/pepa-linha-dark
-	url = https://github.com/pepa-linha/Adminer-Design-Dark/
+	url = git@github.com:pepa-linha/Adminer-Design-Dark.git


### PR DESCRIPTION
I tried to use the `pepa-linha-dark` theme for adminer and noticed some css issues (see image below)

![image](https://github.com/vrana/adminer/assets/46893185/2cd56479-1962-4950-9aa0-6015f37dcd73)

After testing with the latest css-File from https://github.com/pepa-linha/Adminer-Design-Dark/blob/master/adminer.css the issue resolved, so the submodule tracks an old commit.

![image](https://github.com/vrana/adminer/assets/46893185/626ebc35-3edf-471a-8c3f-70a68a431f9b)

This PR updates the submodule to the latest commit.

Im not sure if i specified the path correctly in `.gitmodules` so feel free to correct me