### PR TITLE
PostgreSQL: only show databases you can access

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -274,7 +274,7 @@ if (isset($_GET["pgsql"])) {
 	}
 
 	function get_databases() {
-		return get_vals("SELECT datname FROM pg_database WHERE has_database_privilege(datname, 'CONNECT') ORDER BY datname");
+		return get_vals("SELECT datname FROM pg_database pd JOIN pg_roles pr on pd.datdba = pr.oid WHERE pg_has_role(pr.rolname, 'USAGE') ORDER BY datname");
 	}
 
 	function limit($query, $where, $limit, $offset = 0, $separator = " ") {


### PR DESCRIPTION
When connecting to a PostgreSQL database, Adminer's dropdown also includes all databases you don't have access to, which is not very useful. This commit filters out databases that you don't have the USAGE privilege on, to present a cleaner overview of available databases.