### PR TITLE
Fix mysqli ssl without server certificate

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -27,7 +27,7 @@ if (!defined("DRIVER")) {
 					$database,
 					(is_numeric($port) ? $port : ini_get("mysqli.default_port")),
 					(!is_numeric($port) ? $port : $socket),
-					($ssl ? 64 : 0) // 64 - MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT (not available before PHP 5.6.16)
+					($ssl ? ($ssl['cert'] === '' ? 2048 : 64) : 0) // 2048 - MYSQLI_CLIENT_SSL, 64 - MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT (not available before PHP 5.6.16)
 				);
 				$this->options(MYSQLI_OPT_LOCAL_INFILE, false);
 				return $return;
@@ -50,7 +50,7 @@ if (!defined("DRIVER")) {
 				$row = $result->fetch_array();
 				return $row[$field];
 			}
-			
+
 			function quote($string) {
 				return "'" . $this->escape_string($string) . "'";
 			}
@@ -305,7 +305,7 @@ if (!defined("DRIVER")) {
 			}
 			return queries($prefix . implode(",\n", $values) . $suffix);
 		}
-		
+
 		function slowQuery($query, $timeout) {
 			if (min_version('5.7.8', '10.1.2')) {
 				if (preg_match('~MariaDB~', $this->_conn->server_info)) {
@@ -322,7 +322,7 @@ if (!defined("DRIVER")) {
 				: $idf
 			);
 		}
-		
+
 		function warnings() {
 			$result = $this->_conn->query("SHOW WARNINGS");
 			if ($result && $result->num_rows) {


### PR DESCRIPTION
When I need to connect to Mysql server via SSL but I don't have a server certificate, there is a possibility to setup the connection like the following:

```php
function adminer_object()
{
    // autoloader
    foreach (glob(__DIR__ . '/plugins/*.php') as $filename) {
        require_once $filename;
    }

    $plugins = [
        new AdminerLoginSsl(['key' => '', 'cert' => '', 'ca' => '']),
    ];

    return new AdminerPlugin($plugins);
}

require __DIR__ . '/adminer.php';
```

But unfortunately, it doesn't work with the `MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT` directive. It fails on the error: `Connections using insecure transport are prohibited while --require_secure_transport=ON.`

But with the `MYSQLI_CLIENT_SSL` it works like a charm.