### PR TITLE
PHP 8.3 error suppression

### DIFF
--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -1,6 +1,6 @@
 <?php
 function adminer_errors($errno, $errstr) {
-	return !!preg_match('~^(Trying to access array offset on value of type null|Undefined array key)~', $errstr);
+	return !!preg_match('~^(Trying to access array offset on( value of type)? null|Undefined array key)~', $errstr);
 }
 
 error_reporting(6135); // errors and warnings


### PR DESCRIPTION
PHP 8.3 has shortened the array access on null error message to "Trying to access array offset on null". This commit changes the regular expression used to circumvent errors.