### PR TITLE
feat: plugin "PredefinedLogin"

### DIFF
--- a/plugins/login-predefined.php
+++ b/plugins/login-predefined.php
@@ -1,0 +1,19 @@
+<?php
+
+/** Login with predefined user set in env vars
+* @link https://www.adminer.org/plugins/#use
+* @author Rophy Tsai <rophy123@gmail.com>
+* @license https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+*/
+class PredefinedLogin {
+
+	function credentials() {
+		return array(SERVER, $_ENV["ADMINER_PREDEFINED_USER"], $_ENV["ADMINER_PREDEFINED_PASSWORD"]);
+	}
+
+	function loginFormField($name, $heading, $value) {
+		if ($name == 'username' || $name == 'password') $value = 'Predefined <input type="hidden" name="auth['.$name.']" value="predefined">';
+		return $heading . $value;
+	}
+
+}


### PR DESCRIPTION
A simple login plugin that logins with username/password predefined in server env vars.

This is useful for DB admins to provide a loginless adminer instance to users that can only do things with predefined privileges (e.g. can only read certain granted tables).


![chrome-capture](https://github.com/vrana/adminer/assets/592046/8c6f438b-c22b-4f8e-b58c-0d9f1c5648a2)
