### PR TITLE
MongoDB update not working

### DIFF
--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -480,7 +480,7 @@ if (isset($_GET["mongo"])) {
 		}
 
 		function sql_query_where_parser($queryWhere) {
-			$queryWhere = preg_replace('~^\sWHERE \(?\(?(.+?)\)?\)?$~', '\1', $queryWhere);
+			$queryWhere = preg_replace('~^\sWHERE (.+?)$~', '\1', $queryWhere);
 			$wheres = explode(' AND ', $queryWhere);
 			$wheresOr = explode(') OR (', $queryWhere);
 			$where = array();


### PR DESCRIPTION
'WHERE' parsing was removing the closing paren of object IDs

eg `_id = MongoDB\BSON\ObjectID("66d5e4468b906497efb4cb93"`