### PR TITLE
Separate Collation column in table-structure plugin

### DIFF
--- a/plugins/table-structure.php
+++ b/plugins/table-structure.php
@@ -15,12 +15,12 @@ class AdminerTableStructure {
 	function tableStructurePrint($fields) {
 		echo "<div class='scrollable'>\n";
 		echo "<table class='nowrap odds'>\n";
-		echo "<thead><tr><th>" . lang('Column') . "<th>" . lang('Type') . "<th>" . lang('Nullable') . "<th>" . lang('Default') . (support("comment") ? "<th>" . lang('Comment') : "") . "</thead>\n";
+		echo "<thead><tr><th>" . lang('Column') . "<th>" . lang('Type') . "<th>" . lang('Collation') . "<th>" . lang('Nullable') . "<th>" . lang('Default') . (support("comment") ? "<th>" . lang('Comment') : "") . "</thead>\n";
 		foreach ($fields as $field) {
 			echo "<tr><th>" . h($field["field"]) . ($field["primary"] ? " (PRIMARY)" : "");
 			echo "<td><span>" . h($field["full_type"]) . "</span>";
 			echo ($field["auto_increment"] ? " <i>" . lang('Auto Increment') . "</i>" : "");
-			echo ($field["collation"] ? " <i>" . h($field["collation"]) . "</i>" : "");
+			echo "<td>" . ($field["collation"] ? " <i>" . h($field["collation"]) . "</i>" : "");
 			echo "<td>" . ($field["null"] ? lang('Yes') : lang('No'));
 			echo "<td>" . h($field["default"]);
 			echo (support("comment") ? "<td>" . h($field["comment"]) : "");


### PR DESCRIPTION
Separate Collation column looks better, the collation is not messed in Type column.

![image](https://github.com/user-attachments/assets/4ab38a4a-9b1f-4987-b16b-6e41333d977b)