### PR TITLE
Elastic: Properly display sparse result rows

### DIFF
--- a/plugins/drivers/elastic.php
+++ b/plugins/drivers/elastic.php
@@ -100,7 +100,21 @@ if (isset($_GET["elastic"])) {
 
 			function __construct($rows) {
 				$this->num_rows = count($rows);
-				$this->_rows = $rows;
+
+				$keys = array();
+				foreach ($rows as $row) {
+					foreach ($row as $key => $val) {
+						$keys[$key] = true;
+					}
+				}
+				$this->_rows = array();
+				foreach ($rows as $row) {
+					$insert = array();
+					foreach ($keys as $key => $val) {
+						$insert[$key] = $row[$key];
+					}
+					$this->_rows[] = $insert;
+				}
 
 				reset($this->_rows);
 			}


### PR DESCRIPTION
Result records in Elasticsearch do not always have all columns that are defined in an index.
This often happens when multiple document types are stored in the same index.

The first row has columns ["_id", "html", "url"], while the second misses the "html" column: ["_id", "url"].

Up to now, Adminer expected that all result rows include all columns. This led to the problem that the "url" value in the 2nd example row was rendered in the "html" column.

This patch fixes this problem by iterating over the expected keys, and filling NULL when the database result row misses this key.

(I tried to fix that in the Elasticsearch driver only, but this is much more complicated, since MinDriver::select() does not know about expected field names at all.)

I've verified that MySQL listings look the same as before.

# Screenshots
## Manual column selection: all fine
![2025-02-28 adminer elastic list - manual filtering](https://github.com/user-attachments/assets/5b05c645-23f1-40aa-b0b3-32b22405c194)

## Automatic column selection: bug
Values are rendered in the wrong column
![2025-02-28 adminer elastic list - standard view](https://github.com/user-attachments/assets/f2d9df6d-00e1-4fc2-9273-6f244081ab74)
