### PR TITLE
Elastic: Fix text search on boolean fields

### DIFF
--- a/plugins/drivers/elastic.php
+++ b/plugins/drivers/elastic.php
@@ -143,13 +143,23 @@ if (isset($_GET["elastic"])) {
 				}
 			}
 
+			$fields = null;
 			foreach ($where as $val) {
 				if (preg_match('~^\((.+ OR .+)\)$~', $val, $matches)) {
 					$parts = explode(" OR ", $matches[1]);
 					$terms = array();
+
+					if ($fields === null) {
+						$fields = fields($table);
+					}
 					foreach ($parts as $part) {
 						list($col, $op, $val) = explode(" ", $part, 3);
 						$term = array($col => $val);
+						if (isset($fields[$col]) && $fields[$col]['full_type'] == 'boolean'
+							&& $val !== 'true' && $val !== 'false'
+						) {
+							continue;
+						}
 						if ($op == "=") {
 							$terms[] = array("term" => $term);
 						} elseif (in_array($op, array("must", "should", "must_not"))) {


### PR DESCRIPTION
When searching in all fields for a text value, an error was thrown with ElasticSearch 7.17.23 when the index contains boolean fields:

> query_shard_exception: failed to create query:
> Can't parse boolean value [textvalue], expected [true] or [false]

This patch fixes that problem by skipping boolean fields when the search word is not the string "true" or "false".

----

Now I can finally search for rows containing a certain text by searching for "any" fields with the "should" query.