### PR TITLE
Fix connecting to a MySQL server that has a self-signed SSL certificate

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -246,7 +246,7 @@ if (!defined("DRIVER")) {
 					if (!empty($ssl['ca'])) {
 						$options[PDO::MYSQL_ATTR_SSL_CA] = $ssl['ca'];
 					}
-					if (!empty($ssl['verify'])) {
+					if (isset($ssl['verify'])) {
 						$options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = $ssl['verify'];
 					}
 				}

--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -27,7 +27,7 @@ if (!defined("DRIVER")) {
 					$database,
 					(is_numeric($port) ? $port : ini_get("mysqli.default_port")),
 					(!is_numeric($port) ? $port : $socket),
-					($ssl ? (empty($ssl['cert']) ? 2048 : 64) : 0) // 2048 - MYSQLI_CLIENT_SSL, 64 - MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT (not available before PHP 5.6.16)
+					($ssl ? (!empty($ssl['cert']) ? 2048 : 64) : 0) // 2048 - MYSQLI_CLIENT_SSL, 64 - MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT (not available before PHP 5.6.16)
 				);
 				$this->options(MYSQLI_OPT_LOCAL_INFILE, false);
 				return $return;


### PR DESCRIPTION
Both the MySQLi and PDO_MYSQL interfaces had minor issues that did not allow the use of a self-signed SSL certificate on the database server.

For PDO interface the plugin config needs to set the verify to false. For MySQLi the config needs to not specify a certificate.
