### PR TITLE
Fix PostgreSQL: Show only accessible databases

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -291,8 +291,8 @@ if (isset($_GET["pgsql"])) {
 	}
 
 	function get_databases() {
-		return get_vals("SELECT d.datname FROM pg_database d JOIN pg_roles r ON d.datdba = r.oid
-WHERE d.datallowconn = TRUE AND has_database_privilege(d.datname, 'CONNECT') AND pg_has_role(r.rolname, 'USAGE')
+		return get_vals("SELECT d.datname FROM pg_database d
+WHERE d.datallowconn = TRUE AND has_database_privilege(d.datname, 'CONNECT')
 ORDER BY d.datname");
 	}
 


### PR DESCRIPTION
I made this modification because the original query did not display the list of databases for users who had the necessary permissions. Only Owners and Superusers were able to see the databases, which was incorrect since any user with the appropriate privileges should be able to view them.

The original query attempted to join pg_database with pg_roles based on ownership, restricting the results to database owners and superusers. However, this approach overlooked other users who had the CONNECT privilege on the database.

By modifying the query, I removed the unnecessary JOIN with pg_roles and the check for pg_has_role(r.rolname, 'USAGE'), ensuring that the function correctly returns all databases that the current user has permission to connect to. Now, the query simply checks if a database allows connections (datallowconn = TRUE) and whether the user has the CONNECT privilege on it.

This change ensures that all users with the appropriate permissions can see the databases they have access to, rather than restricting visibility only to owners or superusers.

This is the commit that gave the error:
[https://github.com/vrana/adminer/commit/6e6785ebc45c7679cff01fe2077cd3360377d70c)](https://github.com/vrana/adminer/commit/6e6785ebc45c7679cff01fe2077cd3360377d70c))