### PR TITLE
Make login to Elasticsearch work again

### DIFF
--- a/adminer/elastic.php
+++ b/adminer/elastic.php
@@ -2,8 +2,13 @@
 // To create Adminer just for Elasticsearch, run `../compile.php elastic`.
 
 function adminer_object() {
+	include_once "../plugins/plugin.php";
+	include_once "../plugins/login-password-less.php";
 	include_once "../plugins/drivers/elastic.php";
-	return new Adminer\Adminer;
+	return new AdminerPlugin(array(
+			// TODO: inline the result of password_hash() so that the password is not visible in source codes
+			new AdminerLoginPasswordLess(password_hash("YOUR_PASSWORD_HERE", PASSWORD_DEFAULT)),
+	));
 }
 
 include "./index.php";


### PR DESCRIPTION
By partially reverting the changes made by commit 2c9f380c64ec84a1dc44745df29c5fbf1081fcb0
> Elastic: Remove plugin for version 5

which removed the passwordless login plugin from `adminer/elastic.php`.

Since the passwordless plugin is still enabled for Sqlite, I think the removal for elastic was a mistake.