### PR TITLE
Elastic: Fix record insertion on Elasticsearch 7

### DIFF
--- a/plugins/drivers/elastic.php
+++ b/plugins/drivers/elastic.php
@@ -245,12 +245,23 @@ if (isset($_GET["elastic"])) {
 		}
 
 		function insert($type, $record) {
-			$id = ""; //! user should be able to inform _id
-			$query = "$type/$id";
+			$query = "$type/_doc/";
+			if (isset($record["_id"]) && $record["_id"] != "NULL") {
+				$query .= $record["_id"];
+				unset($record["_id"]);
+			}
+			foreach ($record as $key => $value) {
+				if ($value == "NULL") {
+					unset($record[$key]);
+				}
+			}
 			$response = $this->_conn->query($query, $record, 'POST');
+			if ($response == false) {
+				return false;
+			}
 			$this->_conn->last_id = $response['_id'];
 
-			return $response['created'];
+			return $response['result'];
 		}
 
 		function delete($table, $queryWhere, $limit = 0) {
@@ -466,6 +477,7 @@ if (isset($_GET["elastic"])) {
 				"field" => "_id",
 				"full_type" => "text",
 				"type" => "text",
+				"null" => true,
 				"privileges" => array("insert" => 1, "select" => 1, "where" => 1, "order" => 1),
 			)
 		);
@@ -475,6 +487,7 @@ if (isset($_GET["elastic"])) {
 				"field" => $name,
 				"full_type" => $field["type"],
 				"type" => $field["type"],
+				"null" => true,
 				"privileges" => array(
 					"insert" => 1,
 					"select" => 1,


### PR DESCRIPTION
1. Make values NULLable by default, so that empty values do not get submitted to the Elasticsearch server.
This helps e.g. with empty date fields - Elasticsearch would try to convert the field type to string when the value is an empty string, but that fails when there are documents with properly filled date fields

2. Remove _id from the POST array because this is not allowed. The server fails if it is included with
> mapper_parsing_exception:
> Field [_id] is a metadata field and cannot be added inside a document.
> Use the index API request parameters.

3. Use the correct URL to create a document: "$index/_doc/" and "$index/_doc/$id". This is the same for ES 7 and 8:
- https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-index_.html#docs-index-api-request
- https://www.elastic.co/guide/en/elasticsearch/reference/7.17/docs-index_.html#docs-index-api-request

4. Handle failed creations by checking for false

5. Return the "result" property string instead of the non-existing "created" property.