### PR TITLE
Elastic: Properly display sparse result rows #2

### DIFF
--- a/plugins/drivers/elastic.php
+++ b/plugins/drivers/elastic.php
@@ -205,6 +205,9 @@ if (isset($_GET["elastic"])) {
 			if (empty($search)) {
 				return false;
 			}
+			if ($select == array("*")) {
+				$tableFields = array_keys(fields($table));
+			}
 
 			$return = array();
 			foreach ($search["hits"]["hits"] as $hit) {
@@ -219,7 +222,9 @@ if (isset($_GET["elastic"])) {
 						$fields[$key] = $key == "_id" ? $hit["_id"] : $hit["_source"][$key];
 					}
 				} else {
-					$fields = $hit["_source"];
+					foreach ($tableFields as $key) {
+						$fields[$key] = $key == "_id" ? $hit["_id"] : $hit["_source"][$key];
+					}
 				}
 				foreach ($fields as $key => $val) {
 					$row[$key] = (is_array($val) ? json_encode($val) : $val);


### PR DESCRIPTION
This is the better version of #498, because all rows are displayed instead of only some.

----

Result records in Elasticsearch do not always have all columns that are defined in an index.
This often happens when multiple document types are stored in the same index.

The first row has columns ["_id", "html", "url"], while the second misses the "html" column: ["_id", "url"].

Adminer expects that all result rows include all columns. This leads to the problem that the "url" value in the 2nd example row was rendered in the "html" column.

This patch fixes this problem by fetching the actual column list first when all fields are to be shown, and using that field list as base for all rows.


# Screenshots
## Patch from #498
showing only columns that are in the result rows:
![2025-03-10 adminer elastic 498](https://github.com/user-attachments/assets/c4768c93-9745-4ec1-8fce-f6e139a69c08)

## This patch
showing all rows:
![2025-03-10 adminer elastic 893](https://github.com/user-attachments/assets/0cdf1a8b-53b5-4a81-a412-2b59066a2fa3)
