### PR TITLE
fix gz compression

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -937,7 +937,7 @@ class Adminer {
 			($ext == "sql" || $output != "file" ? "text/plain" : "text/csv") . "; charset=utf-8"
 		)));
 		if ($output == "gz") {
-			ob_start('ob_gzencode', 1e6);
+			ob_start('Adminer\\ob_gzencode', 1e6);
 		}
 		return $ext;
 	}


### PR DESCRIPTION
When exporting database/tables and selecting the gzip output compression ob_start uses the helper function  'ob_gzencode' as callback but without the namespace the output is just a plain/uncompressed sql file with an extra '.gz' suffix