### PR TITLE
Compile: supports visibility modifiers

### DIFF
--- a/compile.php
+++ b/compile.php
@@ -297,7 +297,7 @@ function php_shrink($input) {
 				$doc_comment = true;
 				$token[1] = substr_replace($token[1], "* @version $VERSION\n", -2, 0);
 			}
-			if ($token[0] == T_VAR) {
+			if ($token[0] == T_VAR || $token[0] == T_PUBLIC || $token[0] == T_PROTECTED || $token[0] == T_PRIVATE) {
 				$shortening = false;
 			} elseif (!$shortening) {
 				if ($token[1] == ';') {


### PR DESCRIPTION
Unfortunately, I can't test it because for some reason the compiler is generating invalid files:

```php
<?php
/** Adminer - Compact database management
* @link https://www.adminer.org/
* @author Jakub Vrana, https://www.vrana.cz/
* @copyright 2007 Jakub Vrana
* @license https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
* @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2 (one or other)
* @version 5.0.2
*/namespace
Adminer;namespace
Adminer;namespace
Adminer;$ia="5.0.2";namespace
```