### PR TITLE
Function to retrieve driver name

### DIFF
--- a/adminer/include/driver.inc.php
+++ b/adminer/include/driver.inc.php
@@ -13,6 +13,15 @@ function add_driver($id, $name) {
 	$drivers[$id] = $name;
 }
 
+/** Get driver name
+* @param string
+* @return string
+*/
+function get_driver_name($id) {
+	global $drivers;
+	return $drivers[$id];
+}
+
 /** Get driver
 * @return Driver
 */


### PR DESCRIPTION
This was already merged in PR #438, but broken in fe88f83. Since API has had breaking changes for v5.x, may as well have a better function name.