### PR TITLE
fix: icons background in lucas-sandery design

### DIFF
--- a/designs/lucas-sandery/adminer.css
+++ b/designs/lucas-sandery/adminer.css
@@ -359,8 +359,8 @@ tbody tr:nth-child(n):hover th {
 	background: rgba(236, 72, 18, 0.45);
 }
 .icon {
-	height: 0;
-	padding-top: 1.2em;
+	/*height: 0;
+	padding-top: 1.2em;*/
 	width: 1.2em;
 	background: #4c3957 center no-repeat;
 	background-size: 66%;


### PR DESCRIPTION
hello, with lucas-sandery theme icons for adding/moving/removing fields are not displayed into "alter table" page . I fixed the problem by commenting height and padding-top declarations for .icon class .


