### PR TITLE
Wrap Loaded plugins into div

### DIFF
--- a/adminer/include/connect.inc.php
+++ b/adminer/include/connect.inc.php
@@ -45,12 +45,14 @@ if (
 		echo "<p>" . lang('%s version: %s through PHP extension %s', get_driver(DRIVER), "<b>" . h(connection()->server_info) . "</b>", "<b>" . connection()->extension . "</b>") . "\n";
 		echo "<p>" . lang('Logged as: %s', "<b>" . h(logged_user()) . "</b>") . "\n";
 		if (isset(adminer()->plugins) && is_array(adminer()->plugins)) {
+			echo "<div class='plugins'>\n";
 			echo "<p>" . lang('Loaded plugins') . ":\n<ul>\n";
 			foreach (adminer()->plugins as $plugin) {
 				$reflection = new \ReflectionObject($plugin);
 				echo "<li><b>" . get_class($plugin) . "</b>" . h(preg_match('~^/[\s*]+(.+)~', $reflection->getDocComment(), $match) ? ": $match[1]" : "") . "\n";
 			}
 			echo "</ul>\n";
+			echo "</div>\n";
 		}
 		$databases = adminer()->databases();
 		if ($databases) {


### PR DESCRIPTION
Sometimes it is not that important to have this info.
It will just make easier to move it, hide it, with css instead of js hacks like [this one](https://github.com/dg/adminer/commit/980f57661e170a0ab48bbe1ac34026e4ec5768af).
