### PR TITLE
Allow designs to specify light and dark in one file

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -113,7 +113,7 @@ class Adminer {
 	*/
 	function css(): array {
 		$return = array();
-		foreach (array("", "-dark") as $mode) {
+		foreach (array("", "-dark", "-auto") as $mode) {
 			$filename = "adminer$mode.css";
 			if (file_exists($filename)) {
 				$return[] = "$filename?v=" . crc32(file_get_contents($filename));

--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -37,6 +37,9 @@ function page_header(string $title, string $error = "", $breadcrumb = array(), s
 		if (strpos($filename, "adminer-dark.css") !== false) {
 			$has_dark = true;
 		}
+		if (strpos($filename, "adminer-auto.css") !== false) {
+			$has_light = $has_dark = true;
+		}
 	}
 	$dark = ($has_light
 		? ($has_dark ? null : false) // both styles - autoswitching, only adminer.css - light

--- a/editor/include/adminer.inc.php
+++ b/editor/include/adminer.inc.php
@@ -72,7 +72,7 @@ class Adminer {
 
 	function css() {
 		$return = array();
-		foreach (array("", "-dark") as $mode) {
+		foreach (array("", "-dark", "-auto") as $mode) {
 			$filename = "adminer$mode.css";
 			if (file_exists($filename)) {
 				$return[] = "$filename?v=" . crc32(file_get_contents($filename));


### PR DESCRIPTION
Designs named `adminer-auto.css` would not have to provide both files. This enables simple rule precedence like so:

1. Light rule
2. Dark rule in media query
3. Rule that overrides both previous rules

Two files, with all light rules before the dark rules, forces the latter to have higher precedence. Thus further rules in light can become overly-specific and require more "undoing", if any dark rules affect them.