### PR TITLE
PHPCS.xml: Generic.Whitespace -> Generic.WhiteSpace

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,7 +10,7 @@
 	<exclude-pattern>/(adminer|editor)[-.]</exclude-pattern>
 
 	<rule ref="PSR12">
-		<exclude name="Generic.Whitespace.DisallowTabIndent"/><!-- Replaced by: Generic.Whitespace.DisallowSpaceIndent -->
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/><!-- Replaced by: Generic.WhiteSpace.DisallowSpaceIndent -->
 		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
 		<exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses"/>
 		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/><!-- Replaced by: Generic.Classes.OpeningBraceSameLine -->
@@ -86,7 +86,7 @@
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
 	<rule ref="Generic.Strings.UnnecessaryHeredoc"/>
 	<rule ref="Generic.VersionControl.GitMergeConflict"/>
-	<rule ref="Generic.Whitespace.DisallowSpaceIndent"/>
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
 	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
 
 	<rule ref="Squiz.Arrays.ArrayBracketSpacing"/>


### PR DESCRIPTION
New version of phpcs (PHP_CodeSniffer version 3.12.2 (stable) by Squiz and PHPCSStandards)

Is throwing an error:
```
ERROR: Referenced sniff "Generic.Whitespace.DisallowTabIndent" does not exist.
ERROR: Referenced sniff "Generic.Whitespace.DisallowSpaceIndent" does not exist.
```

I can see that there is already the capital 'S' in a rule list, for example, "Generic.WhiteSpace.ScopeIndent.Incorrect"
so I believe that this should work also in older versions..
