### PR TITLE
Allow override of light/dark mode when auto-detection impossible

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -127,6 +127,13 @@ class Adminer {
 		return $return;
 	}
 
+	/** Specify supported color modes (schemes)
+	* @return list<bool> a pair of booleans to specify light & dark mode, respectively
+	*/
+	function cssModes(): array {
+		return array();
+	}
+
 	/** Print login form */
 	function loginForm(): void {
 		echo "<table class='layout'>\n";

--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -29,18 +29,22 @@ function page_header(string $title, string $error = "", $breadcrumb = array(), s
 <?php
 
 	$css = adminer()->css();
-	$has_light = false;
-	$has_dark = false;
-	foreach ($css as $url) {
-		if (strpos($url, "adminer.css") !== false) {
-			$has_light = true;
-			$filename = preg_replace('~\?.*~', '', $url);
-			if (!preg_match('~//~', $url) && is_readable($filename) && preg_match('~prefers-color-scheme:\s*dark~', file_get_contents($filename))) {
+	if ($css_modes = adminer()->cssModes()) {
+		list($has_light, $has_dark) = $css_modes;
+	} else {
+		$has_light = false;
+		$has_dark = false;
+		foreach ($css as $url) {
+			if (strpos($url, "adminer.css") !== false) {
+				$has_light = true;
+				$filename = preg_replace('~\?.*~', '', $url);
+				if (!preg_match('~//~', $filename) && is_readable($filename) && preg_match('~prefers-color-scheme:\s*dark~', file_get_contents($filename))) {
+					$has_dark = true;
+				}
+			}
+			if (strpos($url, "adminer-dark.css") !== false) {
 				$has_dark = true;
 			}
-		}
-		if (strpos($url, "adminer-dark.css") !== false) {
-			$has_dark = true;
 		}
 	}
 	$dark = ($has_light

--- a/editor/include/adminer.inc.php
+++ b/editor/include/adminer.inc.php
@@ -85,6 +85,10 @@ class Adminer {
 		return $return;
 	}
 
+	function cssModes() {
+		return array();
+	}
+
 	function loginForm() {
 		echo "<table class='layout'>\n";
 		echo adminer()->loginFormField('username', '<tr><th>' . lang('Username') . '<td>', input_hidden("auth[driver]", "server") . '<input name="auth[username]" autofocus value="' . h($_GET["username"]) . '" autocomplete="username" autocapitalize="off">');


### PR DESCRIPTION
Further to #1009, allow setting the correct colour mode for CSS URLs & files specified by `css()`, when auto-detection is impossible or not necessary.