### PR TITLE
Compile: Fix type of $translations_version.

### DIFF
--- a/compile.php
+++ b/compile.php
@@ -166,9 +166,9 @@ function put_file_lang($match) {
 	}
 	$translations_version = crc32($return);
 	return 'Lang::$translations = (array) $_SESSION["translations"];
-if ($_SESSION["translations_version"] != LANG . ' . $translations_version . ') {
+if ($_SESSION["translations_version"] != LANG . "' . $translations_version . '") {
 	Lang::$translations = array();
-	$_SESSION["translations_version"] = LANG . ' . $translations_version . ';
+	$_SESSION["translations_version"] = LANG . "' . $translations_version . '";
 }
 if (!Lang::$translations) {
 	Lang::$translations = get_translations(LANG);


### PR DESCRIPTION
When minified, the space is removed between the constatn and the number `LANG . 12345678` and `LANG.12345678` is not valid because a float is following the constant.