### PR TITLE
`adminer_object()` is not detected

### DIFF
--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -82,7 +82,7 @@ include "../adminer/include/plugins.inc.php";
 include "../adminer/include/plugin.inc.php";
 
 Adminer::$instance =
-	(function_exists('adminer_object') ? adminer_object() :
+	(function_exists('Adminer\adminer_object') ? adminer_object() :
 	(is_dir("adminer-plugins") || file_exists("adminer-plugins.php") ? new Plugins(null) :
 	new Adminer
 ));


### PR DESCRIPTION
 The function `function_exists` doesn't care about current namespace so `adminer_object()` is not detected  even it is defined in a plugin.