### PR TITLE
Add absolute path to plugin filenames

### DIFF
--- a/adminer/include/plugins.inc.php
+++ b/adminer/include/plugins.inc.php
@@ -15,14 +15,15 @@ class Plugins {
 		if ($plugins === null) {
 			$plugins = array();
 			$basename = "adminer-plugins";
-			if (is_dir($basename)) {
-				foreach (glob("$basename/*.php") as $filename) {
-					$include = include_once "./$filename";
+			$cwd = __DIR__ . DIRECTORY_SEPARATOR;
+			if (is_dir("$cwd$basename")) {
+				foreach (glob("$cwd$basename/*.php") as $filename) {
+					$include = include_once $filename;
 				}
 			}
 			$help = " href='https://www.adminer.org/plugins/#use'" . target_blank();
-			if (file_exists("$basename.php")) {
-				$include = include_once "./$basename.php"; // example: return array(new AdminerLoginOtp($secret))
+			if (file_exists("$cwd$basename.php")) {
+				$include = include_once "$cwd$basename.php"; // example: return array(new AdminerLoginOtp($secret))
 				if (is_array($include)) {
 					foreach ($include as $plugin) {
 						$plugins[get_class($plugin)] = $plugin;


### PR DESCRIPTION
In rare cases, Adminer may look for plugins in the wrong directory. This change ensures that the path is always based on the current file location

I run into this issue when I tried to use Adminer from within a Symfony controller. That changes a working directory and so Adminer is looking for files "next to it" in different directories altogether. So I changed relative paths to absolute ones based on the location of the file. 

There's a similar problem with custom CSS files (adminer.css and adminer-dark.css). Adminer looks for them somewhere else and doesn't link them. Making the path absolute doesn't help here, because even if Adminer finds them and links them, they may not be publicly accessible. Adminer would need to load and dump their content to browser. 
I fixed that by intercepting the request to default.css and dark.css and serving the content of custom css instead.  