### PR TITLE
sqlite: fill column lengths when altering table (fix #1141)

### DIFF
--- a/adminer/drivers/sqlite.inc.php
+++ b/adminer/drivers/sqlite.inc.php
@@ -245,6 +245,7 @@ if (isset($_GET["sqlite"])) {
 				"field" => $name,
 				"type" => (preg_match('~int~i', $type) ? "integer" : (preg_match('~char|clob|text~i', $type) ? "text" : (preg_match('~blob~i', $type) ? "blob" : (preg_match('~real|floa|doub~i', $type) ? "real" : "numeric")))),
 				"full_type" => $type,
+				"length" => (preg_match("~^[a-z]+\((\d+)\)$~", $type, $match) ? $match[1] : null),
 				"default" => (preg_match("~^'(.*)'$~", $default, $match) ? str_replace("''", "'", $match[1]) : ($default == "NULL" ? null : $default)),
 				"null" => !$row["notnull"],
 				"privileges" => array("select" => 1, "insert" => 1, "update" => 1, "where" => 1, "order" => 1),


### PR DESCRIPTION
when altering a SQLite table, the length fields are not filled. this might be intentional as SQLite does not really use column lengths, but this fixes the issue and #1141 