### PR TITLE
Bugfix: Correcting pagination in ClickHouse Driver

### DIFF
--- a/plugins/drivers/clickhouse.php
+++ b/plugins/drivers/clickhouse.php
@@ -243,7 +243,14 @@ if (isset($_GET["clickhouse"])) {
 	}
 
 	function limit($query, $where, $limit, $offset = 0, $separator = " ") {
-		return " $query$where" . ($limit ? $separator . "LIMIT $limit" . ($offset ? ", $offset" : "") : "");
+        if (!$limit) {
+            return " $query$where";
+        }
+        $limitClause = "LIMIT " . (int) $limit;
+        if ($offset) {
+            $limitClause .= " OFFSET " . (int) $offset;
+        }
+        return " $query$where" . $separator . $limitClause;
 	}
 
 	function limit1($table, $query, $where, $separator = "\n") {


### PR DESCRIPTION
fix(clickhouse-driver): correct pagination offset handling in LIMIT clause

Previously, the driver used `LIMIT <limit>, <offset>` syntax, causing incorrect
pagination behavior (page 2 repeating results from page 1, etc.). Updated the
`limit()` function to use ClickHouse-compatible `LIMIT <count> OFFSET <offset>`
syntax, ensuring correct row offsets across pages.