### PR TITLE
Connecting to socket did not work after support for ipv6 in 5.4.0

### DIFF
--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -177,7 +177,7 @@ if (!defined('Adminer\DRIVER')) {
 				}
 				list($host, $port) = host_port($server);
 				return $this->dsn(
-					"mysql:charset=utf8;host=$host" . ($port ? (is_numeric($port) ? ";port=" : ";unix_socket=") . $port : ""),
+					"mysql:charset=utf8".(!empty($host) ? ";host=$host" : '') . ($port ? (is_numeric($port) ? ";port=" : ";unix_socket=") . $port : ""),
 					$username,
 					$password,
 					$options

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -839,7 +839,7 @@ function is_shortable(array $field): bool {
 function host_port(string $server) {
 	return (preg_match('~^(\[(.+)]|([^:]+)):([^:]+)$~', $server, $match) // [a:b] - IPv6
 		? array($match[2] . $match[3], $match[4])
-		: array($server, '')
+		: (preg_match('~^(\[(.+)]|([^:]+))$~', $server, $match) ? array($match[2] . $match[3], '') : explode(':', $server, 2)) // Match IPv6 or hostname without port, else split by first colon
 	);
 }
 


### PR DESCRIPTION
<img width="773" height="53" alt="image" src="https://github.com/user-attachments/assets/5338653d-7f0f-4e36-89d1-70b4eb45a8db" />

The commit [f921dafa](https://github.com/vrana/adminer/commit/f921dafa61da0dde151bfddaf0fd27e104fe9078#diff-c82819738ebbfe7ea9821ff520636f41d332c51953a6c828ffa7c2d5a48cfc08R180) breaks behavior that previously worked.

I’ve added comments in the commit messages explaining what each change does and split the commits accordingly.

When the host is empty due to :/unix_socket_path, I now check for that and omit the host in the DSN.

The behavior from [this line](https://github.com/vrana/adminer/commit/f921dafa61da0dde151bfddaf0fd27e104fe9078#diff-c82819738ebbfe7ea9821ff520636f41d332c51953a6c828ffa7c2d5a48cfc08L21) has been moved into the host_port function.

Because 5.4.0 introduced breaking behavior on my part, I manually fixed the adminer.php file like this:
<img width="1256" height="301" alt="image" src="https://github.com/user-attachments/assets/4dacff9c-0d72-41a4-b7ea-51eef7a5ba55" />

Shouldn't the CI tests pass? I agree that I should separate the PRs as suggested in [#1183](https://github.com/vrana/adminer/pull/1183/commits).