### PR TITLE
fix: change cookie value encoding from urlencode to rawurlencode

### DIFF
--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -334,7 +334,7 @@ function convert_fields(array $columns, array $fields, array $select = array()):
 */
 function cookie(string $name, ?string $value, int $lifetime = 2592000): void {
 	header(
-		"Set-Cookie: $name=" . urlencode($value)
+		"Set-Cookie: $name=" . rawurlencode($value)
 			. ($lifetime ? "; expires=" . gmdate("D, d M Y H:i:s", time() + $lifetime) . " GMT" : "")
 			. "; path=" . preg_replace('~\?.*~', '', $_SERVER["REQUEST_URI"])
 			. (HTTPS ? "; secure" : "")


### PR DESCRIPTION
`urlencode` encodes space into `+`, which breaks `adminer_permanent`, which is space-separated.

In current version if multiple connections are made permanent, they are not correctly handled when a new session is created.