### PR TITLE
Fix inheritance links to use correct namespace in PostgreSQL

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -334,11 +334,11 @@ if (isset($_GET["pgsql"])) {
 		}
 
 		function inheritsFrom(string $table): array {
-			return get_vals("SELECT relname FROM pg_class JOIN pg_inherits ON inhparent = oid WHERE inhrelid = " . $this->tableOid($table) . " ORDER BY 1");
+			return get_rows("SELECT relname AS table, nspname AS ns FROM pg_class JOIN pg_inherits ON inhparent = oid JOIN pg_namespace ON relnamespace = pg_namespace.oid WHERE inhrelid = " . $this->tableOid($table) . " ORDER BY 1");
 		}
 
 		function inheritedTables(string $table): array {
-			return get_vals("SELECT relname FROM pg_inherits JOIN pg_class ON inhrelid = oid WHERE inhparent = " . $this->tableOid($table) . " ORDER BY 1");
+			return get_rows("SELECT relname AS table, nspname AS ns FROM pg_inherits JOIN pg_class ON inhrelid = oid JOIN pg_namespace ON relnamespace = pg_namespace.oid WHERE inhparent = " . $this->tableOid($table) . " ORDER BY 1");
 		}
 
 		function partitionsInfo(string $table): array {

--- a/adminer/table.inc.php
+++ b/adminer/table.inc.php
@@ -27,12 +27,13 @@ if ($fields) {
 }
 
 /** Print links to tables
-* @param list<string> $tables
+* @param list<array{table: string, ns: string}> $tables
 */
 function tables_links(array $tables): void {
 	echo "<ul>\n";
-	foreach ($tables as $table) {
-		echo "<li><a href='" . h(ME . "table=" . urlencode($table)) . "'>" . h($table) . "</a>";
+	foreach ($tables as $row) {
+		$link = preg_replace('~ns=[^&]*~', "ns=" . urlencode($row["ns"]), ME);
+		echo "<li><a href='" . h($link . "table=" . urlencode($row["table"])) . "'>" . h($row["table"]) . "</a>";
 	}
 	echo "</ul>\n";
 }


### PR DESCRIPTION
## Summary
- Fixed "Inherits from" and "Inherited by" links showing wrong namespace (always "public")
- Modified `inheritsFrom()` and `inheritedTables()` to return namespace with table name
- Updated `tables_links()` to generate URLs with correct namespace