### PR TITLE
[ci] Allow for manual on-demand CI runs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build-test:


### PR DESCRIPTION
When you allow manual CI runs, users can easily test their branches even before opening a PR. It might be a good idea to also run CI on push to any branch, but that is a problem for the future.

When I ran the manual test for master branch in my repo, it fails the phpcs test though:

```text
Building PHP latest with extensions:  ...
Command: phpcs . --standard=phpcs.xml --report=full
ERROR: Referenced sniff "Generic.Functions.CallTimePassByReference" does not exist.
ERROR: Referenced sniff "Squiz.CSS.ClassDefinitionNameSpacing" does not exist.
ERROR: Referenced sniff "Squiz.CSS.ColonSpacing" does not exist.
ERROR: Referenced sniff "Squiz.CSS.DuplicateClassDefinition" does not exist.
ERROR: Referenced sniff "Squiz.CSS.DuplicateStyleDefinition" does not exist.
ERROR: Referenced sniff "Squiz.CSS.EmptyClassDefinition" does not exist.
ERROR: Referenced sniff "Squiz.CSS.EmptyStyleDefinition" does not exist.
ERROR: Referenced sniff "Squiz.CSS.ForbiddenStyles" does not exist.
ERROR: Referenced sniff "Squiz.CSS.Indentation" does not exist.
ERROR: Referenced sniff "Squiz.CSS.MissingColon" does not exist.
ERROR: Referenced sniff "Squiz.CSS.Opacity" does not exist.
ERROR: Referenced sniff "Squiz.CSS.SemicolonSpacing" does not exist.
ERROR: Referenced sniff "Squiz.Objects.ObjectMemberComma" does not exist.

Run "phpcs --help" for usage information
```

Unfortunately, when even master fails, I have no way to test my patch I'm working on.