### PR TITLE
check if "val-" exists in enum value

### DIFF
--- a/adminer/include/html.inc.php
+++ b/adminer/include/html.inc.php
@@ -317,7 +317,9 @@ function process_input(array $field) {
 		if ($value == "null") {
 			return "NULL";
 		}
-		$value = substr($value, 4); // 4 - strlen("val-")
+		if (preg_match('~val-~', $value)) {
+			$value = substr($value, 4); // 4 - strlen("val-")
+		}
 	}
 	if ($field["auto_increment"] && $value == "") {
 		return null;


### PR DESCRIPTION
Problem probably introduced in #1152 
Some enum values seem to not be prefixed with "val-" leading to SQL Errors on insertion