### PR TITLE
security: add allowed_classes => false to unserialize() in brute-force protection

### DIFF
--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -24,7 +24,7 @@ function add_invalid_login(): void {
 	if (!$fp) {
 		return;
 	}
-	$invalids = unserialize(stream_get_contents($fp));
+	$invalids = unserialize(stream_get_contents($fp), ['allowed_classes' => false]);
 	$time = time();
 	if ($invalids) {
 		foreach ($invalids as $ip => $val) {
@@ -47,7 +47,7 @@ function check_invalid_login(array &$permanent): void {
 	foreach (glob(get_temp_dir() . "/adminer.invalid*") as $filename) {
 		$fp = file_open_lock($filename);
 		if ($fp) {
-			$invalids = unserialize(stream_get_contents($fp));
+			$invalids = unserialize(stream_get_contents($fp), ['allowed_classes' => false]);
 			file_unlock($fp);
 			break;
 		}


### PR DESCRIPTION
## Summary

`auth.inc.php` reads serialized brute-force tracking data from temp files and passes it to `unserialize()` without specifying `allowed_classes`.

The stored data structure is `array<ip_address, [expiry_time, count]>` — plain arrays of integers. There's no reason for objects here.

Without the restriction, an attacker who can write to the temp directory (e.g., through a path traversal or a symlink attack on the temp file path) can plant a serialized object payload that gets instantiated when Adminer reads its brute-force protection data.

## Fix

Added `['allowed_classes' => false]` to both `unserialize()` calls in `auth.inc.php`. Zero behavior change for valid data.