### PR TITLE
Allow colon in socket path

### DIFF
--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -173,7 +173,7 @@ if (isset($_GET["username"]) && !class_exists('Adminer\Db')) {
 $connection = '';
 if (isset($_GET["username"]) && is_string(get_password())) {
 	list($host, $port) = host_port(SERVER);
-	if (!preg_match('~^[-a-z0-9.:]*$~Di', $host) || !preg_match('~^[-\w./]*$~D', $port)) {
+	if (!preg_match('~^[-a-z0-9.:]*$~Di', $host) || !preg_match('~^[-\w.:/]*$~D', $port)) {
 		auth_error(lang('Invalid server.'), $permanent);
 	}
 	if (preg_match('~^-?\d+~', $port, $match) && ($match[0] < 1024 || $match[0] > 65535)) { // is_numeric('80.') would still connect to port 80

--- a/adminer/include/functions.inc.php
+++ b/adminer/include/functions.inc.php
@@ -865,7 +865,7 @@ function is_shortable(array $field): bool {
 * @return array{0: string, 1: string}
 */
 function host_port(string $server) {
-	return (preg_match('~^(\[(.+)]|([^:]*)):([^:]+)$~', $server, $match) // [a:b] - IPv6
+	return (preg_match('~^(\[(.+)]|([^:]*)):(\d+|/.+)$~', $server, $match) // [a:b] - IPv6
 		? array($match[2] . $match[3], $match[4])
 		: array($server, '')
 	);


### PR DESCRIPTION
Fixes a regression introduced by 3faf0957 (GHSA-58cq-mgw2-38m5) that made host_port() reject server strings where the socket/port portion contains a colon, causing a spurious "Invalid server." error. This breaks connecting via socket paths that legitimately contain colons, e.g.:
`:/cloudsql/project:region:instance` (Google Cloud SQL Unix socket)
`:/var/www/mysql.sock`

**Changes**
`adminer/include/auth.inc.php`: allow `:` in the validated port/socket pattern `([-\w./]*` → `[-\w.:/]*)`, matching what `host_port()` can return.
`adminer/include/functions.inc.php`: `host_port()`'s port/socket capture group changed from `[^:].+` to `[^:].*`. The `.+` required at least 2 characters after the colon, so a single-character port (e.g. `localhost:5`) failed to match and was returned unsplit as the host instead of being split into (host, port). Since the host pattern permits colons, this let a single-character port slip past the privileged-port check (< `1024`) entirely, as the port value it checks was left empty. `.*` restores splitting for 1-character ports/sockets too.