### PR TITLE
before-unload: the page is being left, not reloaded (cs, de)

### DIFF
--- a/plugins/before-unload.php
+++ b/plugins/before-unload.php
@@ -33,8 +33,8 @@ onbeforeunload = () => editChanged;
 	}
 
 	protected $translations = array(
-		'cs' => array('' => 'Zobrazí potvrzení před odnahráním stránky, pokud bylo změněno formulářové políčko'),
-		'de' => array('' => 'Zeigt eine Bestätigung an bevor die Seite neu geladen wird, wenn ein Formularfeld geändert wurde'),
+		'cs' => array('' => 'Zobrazí potvrzení před opuštěním stránky, pokud bylo změněno formulářové políčko'),
+		'de' => array('' => 'Zeigt eine Bestätigung an bevor die Seite verlassen wird, wenn ein Formularfeld geändert wurde'),
 		'ja' => array('' => 'フォームの列が変更された時、ページを再読込みする前に確認を表示'),
 		'pl' => array('' => 'Wyświetlaj potwierdzenie przed rozładowaniem strony, jeśli pole formularza zostało zmienione'),
 		'hr' => array('' => 'Prikazuje potvrdu prije napuštanja stranice ako je polje obrasca promijenjeno'),


### PR DESCRIPTION
The description of the before-unload plugin says the confirmation appears before the page is *reloaded* in German, which is narrower than what the code does: `onbeforeunload` fires whenever the page goes away — closing the tab, navigating elsewhere, or a reload.

- **de**: "bevor die Seite neu geladen wird" (before the page is reloaded) → "bevor die Seite verlassen wird".
- **cs**: "odnahráním" is not a word Czech uses for this; "opuštěním" is what the Croatian and Polish strings already say ("napuštanja", "rozładowaniem" → leaving).

The English doc-comment, `hr` and `pl` are correct and untouched. `ja` reads "before reloading the page" (再読込み) too, so it may want the same fix, but I do not speak Japanese well enough to propose the wording.