### PR TITLE
PHPStan: Drop the booleanAnd.alwaysFalse ignore, unused since 2.2.6

### DIFF
--- a/conf/phpstan.neon
+++ b/conf/phpstan.neon
@@ -43,7 +43,6 @@ parameters:
 		- identifier: notIdentical.alwaysTrue
 		- identifier: booleanNot.alwaysTrue
 		- identifier: booleanNot.alwaysFalse
-		- identifier: booleanAnd.alwaysFalse
 		- identifier: booleanAnd.leftAlwaysTrue
 		- identifier: booleanAnd.rightAlwaysTrue
 		- identifier: booleanAnd.rightAlwaysFalse


### PR DESCRIPTION
CI is currently red on `main` itself, not just on pull requests:

```
Ignored error pattern booleanAnd.alwaysFalse was not matched in reported errors.
[ERROR] Found 1 error
```

No code reports `booleanAnd.alwaysFalse` any more, so the ignore in `conf/phpstan.neon` is unmatched and `reportUnmatchedIgnoredErrors` (on by default) fails the run.

Bisected against an unmodified checkout of 29623c3, same config, PHP 8.4:

| PHPStan | Result |
| --- | --- |
| 2.2.5 | `[OK] No errors` |
| 2.2.6 | `[ERROR] Found 1 error` |
| 2.2.7 | `[ERROR] Found 1 error` |

With this line dropped, 2.2.7 gives `[OK] No errors`.

Nothing was committed to break it — `php-actions/phpstan@v3` is used with `version: latest`, so the new PHPStan arrived on its own. Worth noting the workflow only triggers on `pull_request` and `workflow_dispatch`, so a red `main` is invisible until someone opens a PR.

If you would rather this could not happen again, pinning the PHPStan version in `.github/workflows/ci.yml` would do it, but that is your call and not in this change.