### PR TITLE
e2e tests

### DIFF
--- a/.claude/skills/e2e-tests/SKILL.md
+++ b/.claude/skills/e2e-tests/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: e2e-tests
+description: Write or change Adminer's browser end-to-end tests in tests/e2e/ - Gherkin features run by Behat. Use when adding a scenario or a step, changing the seed data, adding a database driver to the suite, or debugging a failing e2e run.
+---
+
+# Writing Adminer's end-to-end tests
+
+Gherkin scenarios run by Behat, driving Playwright against the dev version and a Testcontainers
+database. [The README](../../../tests/e2e/README.md) has the layout and the commands - read it
+first. This is what writing one has to get right.
+
+## Running anything at all
+
+If `php` is not on the PATH, everything goes through the dev container, which has PHP with the
+database extensions, Composer, Node and the browser already in it:
+
+```bash
+npx @devcontainers/cli up --workspace-folder .                    # once, a few minutes
+npx @devcontainers/cli exec --workspace-folder . composer e2e     # any command, inside
+```
+
+Attaching to the container by hand, note the user: `docker exec -u vscode`, never as root. The
+browser is installed under `/home/vscode`, and root's run skips every scenario with "Executable
+doesn't exist", which reads like a broken suite and is a wrong `-u`.
+
+A `vendor/` left at the repository root from before the tests got their own composer.json shadows
+their Behat - it is gitignored, so no checkout cleans it - and `composer e2e` then dies with
+"`AdminerContext` context class not found" before a scenario runs. Delete it; a fresh root install
+brings no packages, and behat then falls back to the autoloader in `tests/e2e/vendor` as intended.
+
+Do not improvise a PHP instead - no source builds, no ad-hoc `docker run php:8.4-cli`. A bare PHP
+image looks like it would work and cannot: it has no browser, and the databases Testcontainers
+starts are on the host's daemon, which a container reaches only through the socket and
+`TESTCONTAINERS_HOST_OVERRIDE`. Both are wired up in `.devcontainer/`, and nowhere else.
+
+## Reach for an existing step first
+
+`composer e2e -- -di` lists every step. A feature written in steps that
+already exist is the point of the exercise; a new step is added to `AdminerContext` only when the
+scenario genuinely does something new.
+
+Name a step for what the **user** is doing, not for what the browser is doing:
+
+- `When I sort by the "name" column` — not `When I click the second heading link`
+- `Then the table lists 6 rows` — not `Then #table tbody tr has length 6`
+
+A step that names a CSS selector has leaked the implementation into the feature file, where the
+next person cannot read it.
+
+## Where a scenario goes
+
+The directory decides which drivers run a feature, so putting it in the right one is the first
+decision, not an afterthought:
+
+- `features/shared/` runs against **every** driver, so it may only use what all of them do.
+- `features/<driver>/` runs against that one only - use it when the behaviour needs a type, a
+  syntax or a page a single driver has, rather than putting an `if` on the driver in a step.
+
+A feature that fits some drivers but not all is the one case for a tag, filtered per suite in
+behat.yml. There is none yet; do not add the second mechanism before there is.
+
+## Scenarios must not depend on each other
+
+They share one database per driver and run in file order, which is not an order to rely on:
+
+- A scenario that writes starts from a known state: `Given the "notes" table is empty`.
+- It writes only to tables no other feature reads (`notes`, or a row it inserts itself).
+- Never leave a seeded row changed - a scenario that edits `articles` inserts its own row instead.
+
+## Seed data
+
+`tests/e2e/seed/<driver>.sql`, one file per driver:
+
+- **English**, and the same tables and rows in every file - the shared features compare against
+  them. Only the types differ, and only where they have to.
+- **Keep the accents** (`Amélie Fontaine`, `Eero Väisälä`). They are what a broken encoding loses,
+  and asserting on them is free coverage of the whole path.
+- Tables only one driver has go **after** the shared ones, in that driver's file alone, with a
+  comment naming the feature that reads them.
+- Order the rows so that sorting visibly reorders them - seeded by id, not alphabetically.
+
+## Writing a step
+
+In `tests/e2e/bootstrap/AdminerContext.php`, as a PHP attribute:
+
+```php
+#[When('I sort by the :column column')]
+public function sortBy(string $column): void {
+	$this->page->click("[id=\"th[$column]\"] > a");
+	$this->page->waitForLoadState("networkidle");
+}
+```
+
+- Throw `RuntimeException` to fail, and say what was found: `"row 1 is '$row'"`, not `"wrong row"`.
+  Behat reports the step, the file and the line on its own.
+- Annotate JavaScript with `/** @lang JavaScript */` directly before the string, including inside a
+  call, so that an IDE highlights it.
+- Arrange through `e2e_connect()` when the browser is not the point - emptying a table is setup,
+  not behaviour.
+
+## Selectors
+
+- No tag name where the drivers differ: a `text` column is a textarea in one driver and an input
+  in another, so `[name="fields[title]"]`, never `input[name="fields[title]"]`.
+- Adminer's ids contain brackets: `[id="th[name]"] > a` is the sort link of a column, and the
+  `> a` matters - the search and descending links are in a span next to it.
+- Prefer what Adminer names (`#logout`, `#breadcrumb`, `#tables`, `#table`, `#form`) over positions.
+- A selector which can match a row must say which one: `locator(...)->first()`, not `click(...)`.
+  Matching two elements is a strict mode violation, and the client checks visibility before
+  clicking, swallows the violation as "not visible yet" and retries - so it surfaces thirty seconds
+  later as `Element not actionable`, about an element which is on screen and perfectly clickable.
+  `#table tbody tr a.edit` is every row's edit link; it passed for months only because the tables it
+  ran against held one row.
+
+## Navigation
+
+- After a click that navigates: `waitForLoadState("networkidle")`.
+- After something JavaScript navigates on its own (a select that submits its form):
+  `waitForURL("**ns=analytics**")` first - the URL changes a beat after the call returns, and
+  waiting only for a quiet network reads the old page. This has already caused one failure that
+  appeared on MySQL and not on PostgreSQL, purely because of timing.
+- Never `evaluate()` something that navigates: the call dies with "Execution context was
+  destroyed". Defer it with `setTimeout(..., 0)` and then wait for the URL.
+
+## Style
+
+`phpcs` runs over `tests/` with the repository's ruleset: tabs, `array()` and not `[]`, braces
+always, lines under 200 characters. Doc-comments are imperative and have no trailing period.
+`conf/phpstan-e2e.neon` checks the same directory apart from Adminer, because the tests are a PHP
+8.2 codebase which never ships - they have their own `composer.json`, installed by
+`composer install -d tests/e2e`.
+
+## Checking the work
+
+```bash
+composer e2e -- tests/e2e/features/shared/<name>.feature   # the feature that was touched
+composer e2e -- --stop-on-failure                   # stop at the first, for a fast loop
+composer e2e -- --dry-run                           # every step resolves, no browser, no database
+composer e2e -- -di                                 # every step that can be written
+composer e2e                                        # both drivers, always before pushing
+```
+
+A failing step writes `tests/e2e/artifacts/<driver>-<feature>-<line>.{png,html}` - look at those
+before guessing.
+
+The whole suite is about a minute and a half. Anything near fifteen means it is not failing, it is
+hanging - see below.
+
+## When the run hangs instead of failing
+
+Everything in this section was paid for once already; none of it is hypothetical.
+
+**Reach for `--stop-on-failure` first.** A hanging suite spends thirty seconds per timeout and
+cascades, so the same bug costs fifteen minutes to see once. Stopping at the first one turned that
+into a seventy-second reproduction, and every experiment after it was cheap. Do this before
+forming a theory.
+
+**A timeout naming a JSON-RPC request number is not a test failure.** `JSON-RPC request 182 timed
+out` means the PHP client stopped waiting, not that the browser did anything. It names no step and
+no page, and `e2e_report()` cannot save a screenshot through a transport in that state, so the
+artifacts are of the run before. The transport is deliberately given longer than an action
+(`PlaywrightConfig(timeoutMs: 60000)` against Playwright's 30 000) so the answer is always read and
+the real message - `page.goto: Timeout 30000ms exceeded` - reaches the report. Never make the two
+equal again.
+
+**Suspect the web server's stderr before suspecting the browser.** `php -S` logs every request it
+serves, `Symfony\Process` holds that pipe and drains it only when something asks for the output,
+and nothing does. Sixty-four kilobytes in - four or five scenarios - the pipe fills, the server
+blocks writing to it and serves nothing more. `e2e_boot()` calls `disableOutput()` for exactly
+this. It presents as a page that commits and never finishes loading, in a different scenario each
+run depending on how many requests came before, which looks like flakiness and is arithmetic.
+
+**A screenshot that also times out means the page is wedged, not slow.** When `page.screenshot`
+times out next to the failing step, no navigation option will help - `domcontentloaded` hangs just
+as `load` does. Look for what is holding the page, not for a better thing to wait on.
+
+**Curl the dev server while it hangs.** One `curl` against the port the run is using separates a
+wedged server from a wedged browser in seconds, and it is worth doing before any theory. It also
+lies in one specific way: an already-accepted request is served from a buffer the server still has
+room for, so a sub-millisecond answer does not fully clear it.
+
+**Bisect by feature, not by reasoning.** `composer test -- --suite=pgsql features/a.feature
+features/b.feature` runs any combination. Which pairs hang and which do not is worth more than any
+amount of reading the harness - here it showed the count of requests mattered and their content
+did not.
+
+**A killed run leaks its `php -S`.** It dies with the PHP process which started it, and `pkill` and
+Ctrl-C skip that, so debugging leaves servers on 18080 upward. `e2e_free_port()` walks past them and
+the suite still runs, but check for strays before blaming a port.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,67 @@
+{
+	// A development environment for Adminer which needs nothing installed but Docker: PHP with the
+	// database extensions, Composer, Node, and the browser the end-to-end tests drive.
+	//
+	// Open the repository in it (VS Code, IntelliJ, GitHub Codespaces) or use it from a terminal:
+	//
+	//     npx @devcontainers/cli up --workspace-folder .
+	//     npx @devcontainers/cli exec --workspace-folder . composer e2e
+	//
+	// See tests/e2e/README.md for what the tests need and how they are run.
+	"name": "Adminer",
+	"image": "mcr.microsoft.com/devcontainers/php:8.4",
+
+	"features": {
+		// The tests start their databases through Testcontainers, which needs a Docker daemon.
+		// Outside-of-docker forwards to the one on the host instead of nesting a second one, so the
+		// databases are containers next to this one and the host's image cache is reused.
+		// moby - the image is Debian trixie, which has no moby-cli package; this installs Docker's
+		// own CLI instead, which is what the feature suggests when it fails on it.
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"moby": false
+		},
+		// Playwright downloads and runs its browser through npm.
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "lts"
+		},
+		// `composer e2e-visual` shows the browser, and a browser needs somewhere to draw. This is an
+		// X server with a window manager and a VNC server in front of it, reachable in a browser on
+		// port 6080 (the password is the default, "vscode"); it sets DISPLAY, which is what
+		// Playwright refuses to start a headed browser without.
+		"ghcr.io/devcontainers/features/desktop-lite:1": {}
+	},
+
+	"containerEnv": {
+		// The databases are started next to this container, not in it, so 127.0.0.1 is the wrong
+		// address for them; Testcontainers rewrites it to this one.
+		"TESTCONTAINERS_HOST_OVERRIDE": "host.docker.internal",
+		// The image sets Xdebug up to connect to an IDE, which prints two lines about failing to
+		// on every single PHP run. Set it to debug, develop or coverage when it is wanted.
+		"XDEBUG_MODE": "off",
+		// Taller than the browser the tests open, which is the 1280x900 viewport they set plus the
+		// chrome around it. The desktop is 1440x768 by default, the window does not fit on it, and
+		// what you watch is a browser hanging off the edge of its own screen.
+		"VNC_RESOLUTION": "1920x1080x16"
+	},
+
+	"postCreateCommand": ".devcontainer/setup.sh",
+
+	// 8000 - php -S 127.0.0.1:8000 -t . serves the dev version, see the README.
+	// 6080 - the desktop above, to watch `composer e2e-visual` drive the browser.
+	"forwardPorts": [8000, 6080],
+
+	// The desktop again, published by Docker rather than forwarded by the editor. forwardPorts is
+	// something an editor does when it feels like it - VS Code does, others do not - and a desktop
+	// nobody can open is the same as no desktop. This one is mapped whoever starts the container.
+	"appPort": ["6080:6080"],
+
+	// Open the desktop when it is forwarded, for the editors which do that. Nothing inside the
+	// container can open a browser on the host - it has no way to reach the window server - so
+	// where the editor does not, the README says which command to run on the machine itself.
+	"portsAttributes": {
+		"6080": {
+			"label": "e2e desktop (watch composer e2e-visual)",
+			"onAutoForward": "openBrowser"
+		}
+	}
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -e
+# Everything the container needs once, run by devcontainer.json after it is created.
+
+# The drivers the end-to-end tests connect with. The image is the official PHP one underneath, so
+# the extensions are built with its own tool; only PostgreSQL needs a library for it, MySQL is
+# served by the mysqlnd already in there.
+sudo apt-get update -qq
+sudo apt-get install -y -qq libpq-dev
+# -E: docker-php-ext-* write to $PHP_INI_DIR, which plain sudo drops from the environment.
+sudo -E docker-php-ext-install -j"$(nproc)" pdo_pgsql pgsql mysqli pdo_mysql
+
+# Adminer has no dependencies; this initializes the submodules, the dev version needs jush for
+# syntax highlighting, and it installs the ESLint used by `composer check`.
+composer install --no-interaction
+
+# The tools `composer check` runs. They are Adminer's, not the repository's, which is why they are
+# installed for the user and not required by composer.json.
+composer global require --no-interaction phpstan/phpstan squizlabs/php_codesniffer
+
+# The tests have a composer.json of their own, see tests/e2e/README.md.
+composer install -d tests/e2e --no-interaction
+
+# The Playwright server, then the libraries the browser needs and the browser itself - the only
+# one the tests use, the default installs three.
+php tests/e2e/vendor/bin/playwright-install
+cd tests/e2e/vendor/playwright-php/playwright/bin
+# The libraries are apt packages, so root, and PATH is passed along because Node is installed for
+# the user and sudo would not find it. --no-install so that this is the Playwright the tests run,
+# not whichever one npx would fetch.
+sudo -E env "PATH=$PATH" npx --no-install playwright install-deps chromium
+# The browser itself as the user, so that it lands in the cache the tests read.
+npx --no-install playwright install chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ jobs:
         with:
           version: latest
           configuration: conf/phpstan.neon
+      # The end-to-end tests are checked apart from Adminer, see the configuration for why. Their
+      # dependencies are what PHPStan loads to know the classes they use.
+      - run: composer install -d tests/e2e --no-interaction --no-progress
+      - uses: php-actions/phpstan@v3
+        with:
+          version: latest
+          php_version: "8.4"
+          configuration: conf/phpstan-e2e.neon
+          memory_limit: 1G
       - uses: actions/setup-node@v7
         with:
           node-version: lts/*

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,41 @@
+name: End-to-end tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pgsql, pdo_pgsql, mysqli, pdo_mysql
+      - uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+      # Adminer itself has no dependencies; this initializes the submodules, the dev version needs
+      # jush for syntax highlighting.
+      - run: composer install --no-interaction --no-progress
+      # The tests have a composer.json of their own, see tests/e2e/README.md.
+      - run: composer install -d tests/e2e --no-interaction --no-progress
+      # The Playwright server, then the only browser the tests use (the default installs three).
+      - run: tests/e2e/vendor/bin/playwright-install
+      - run: npx --no-install playwright install --with-deps chromium
+        working-directory: tests/e2e/vendor/playwright-php/playwright/bin
+      # Both suites, one per driver, see tests/e2e/behat.yml. Behat colours its output only when it
+      # is talking to a terminal and a workflow step is not one, so it is asked for it explicitly -
+      # passed and failed are otherwise the same shade of nothing in the log.
+      - run: composer e2e -- --colors
+      # The screenshot and the HTML of every page a step failed on, which is all there is to
+      # look at once the run is over.
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-failures
+          path: tests/e2e/artifacts/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@
 /tests/pdo-*.html
 /tests/screenshots/
 /tests/cropped/
+/tests/e2e/artifacts/
+/tests/e2e/vendor/
+/tests/e2e/composer.lock
+/.cache/
+/.devcontainer/devcontainer-lock.json
 /vendor/
 /composer.lock
 /node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - ESLint: Install it by composer install, run it in composer check and CI
 - Docs: Handling of values and binary data, plugin translations, CSS changes must not break skins
 - Rename the Git master branch to main
+- Add browser end-to-end tests running against PostgreSQL and MySQL, run them in CI
 
 ## Adminer 5.5.1 (released 2026-07-21)
 - Ignore invalid X-Forwarded-Prefix (GHSA-fr74-9mf9-gf44)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
+**If the machine has no PHP, run everything in the dev container** – it needs only Docker and
+brings PHP with the database extensions, Composer, Node and the browser the e2e tests drive:
+```bash
+npx @devcontainers/cli up --workspace-folder .                   # once, a few minutes
+npx @devcontainers/cli exec --workspace-folder . composer e2e    # any command below, inside
+```
+Do not reach for a PHP of your own making instead – no source builds, no ad-hoc `docker run php`.
+Everything below assumes either a PHP on the PATH or that prefix.
+
 **First-time setup:**
 ```bash
 git submodule update --init --recursive   # Initialize submodules (jush, JsShrink, PhpShrink)
@@ -37,6 +46,8 @@ composer clean    # Remove all compiled adminer*.php and editor*.php
 ```
 
 **Tests:** Browser-based end-to-end tests in `tests/*.html` (Katalon Recorder format). No unit test runner. Standalone unit tests: `tests/compress.php` (string compression round-trip and pure-PHP inflate fallback) and `tests/host_port.php` (host:port parsing) – run directly with `php`, they print errors and exit 0 when OK.
+
+**End-to-end tests:** Gherkin scenarios run by Behat against PostgreSQL and MySQL started by Testcontainers – `composer e2e`, needs Docker and `composer install -d tests/e2e`. They have a composer.json of their own; see [tests/e2e/README.md](tests/e2e/README.md) and the `e2e-tests` skill before writing one.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If downloaded from Git then run: `git submodule update --init` (or `composer ins
 - `compile.php` - Create a single file version
 - `lang.php` - Update translations
 - `tests/*.html` - Katalon Recorder test suites
+- `tests/e2e/` - Browser end-to-end tests, run by `composer e2e` ([how they work](tests/e2e/README.md))
 
 ## Plugins
 There are several plugins distributed with Adminer, as well as many user-contributed plugins listed on the [Adminer Plugins page](https://www.adminer.org/plugins/).

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "require": {
         "php": ">=7.4"
     },
+    "config": {
+        "process-timeout": 0
+    },
     "scripts": {
         "post-install-cmd": "@submodules",
         "post-update-cmd": "@submodules",
@@ -39,9 +42,15 @@
         "check": [
             "phpcs --standard=conf/phpcs.xml",
             "phpstan analyse -c conf/phpstan.neon",
+            "phpstan analyse -c conf/phpstan-e2e.neon",
             "npx eslint -c conf/eslint.config.mjs"
         ],
         "compile": "@php compile.php",
+        "e2e": "@php tests/e2e/vendor/bin/behat -c tests/e2e/behat.yml",
+        "e2e-visual": [
+            "@putenv ADMINER_E2E_HEADED=1",
+            "@php tests/e2e/vendor/bin/behat -c tests/e2e/behat.yml"
+        ],
         "clean": "@php -r \"array_map('unlink', array_merge(glob('adminer*.php'), glob('editor*.php')));\""
     }
 }

--- a/conf/eslint.config.mjs
+++ b/conf/eslint.config.mjs
@@ -33,7 +33,10 @@ function merge(prepended) {
 }
 
 export default [
-	{ignores: ["externals/"]}, // a config with only ignores is global; not globalIgnores() to not require the eslint package itself
+	// a config with only ignores is global; not globalIgnores() to not require the eslint package itself
+	// vendor/ - Composer installs the JavaScript of the Playwright server the end-to-end tests
+	// drive, which is written for a newer ECMAScript than the one pinned below
+	{ignores: ["externals/", "**/vendor/"]},
 	js.configs.recommended,
 	{
 		files: ["**/*.js"], // not this .mjs config

--- a/conf/phpcs.xml
+++ b/conf/phpcs.xml
@@ -85,7 +85,9 @@
 	<rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
 	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
 	<rule ref="Generic.Files.EndFileNewline"/>
-	<rule ref="Generic.Files.LowercasedFilename"/>
+	<rule ref="Generic.Files.LowercasedFilename">
+		<exclude-pattern>/tests/e2e/bootstrap/</exclude-pattern><!-- Behat autoloads the context class by its file name -->
+	</rule>
 	<rule ref="Generic.Formatting.SpaceAfterCast"/>
 	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
 	<rule ref="Generic.NamingConventions.ConstructorName"/>

--- a/conf/phpstan-e2e.neon
+++ b/conf/phpstan-e2e.neon
@@ -1,0 +1,25 @@
+# The end-to-end tests are checked apart from Adminer itself because they are a different
+# codebase, down to a composer.json of their own: they never ship, they run on the PHP the
+# developer has, and their dependencies require PHP 8.2. phpstan.neon analyzes as PHP 7.1, where
+# `mixed` is not a type yet, so the same run would report every `mixed` in those packages as a
+# missing class.
+parameters:
+	level: 6
+
+	# Behat, Playwright and Testcontainers, installed by `composer install -d tests/e2e`.
+	bootstrapFiles:
+		- ../tests/e2e/vendor/autoload.php
+
+	paths:
+		- ../tests/e2e/
+	excludePaths:
+		- ../tests/e2e/vendor/ # inside the analyzed directory now, unlike Adminer's own
+
+	# The whole range the tests declare they run on, so that the code is checked against both ends.
+	phpVersion:
+		min: 80200
+		max: 80500
+
+	typeAliases:
+		E2eDriver: "array{name:string, key:string, port:int, username:string, password:string}"
+		E2eFixture: "array{root:string, artifacts:string, server:Symfony\\Component\\Process\\Process, base:string, database:string, driver:E2eDriver}"

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -281,6 +281,17 @@ These tests verify correct behavior, including UI functionality, which is otherw
 The tests take about 10 minutes to run, which is acceptable before a release.
 They help detect even JavaScript errors in real-world use cases.
 
+There are also automated end-to-end tests in [tests/e2e/](/tests/e2e/), run by `composer e2e` and by a GitHub workflow on every pull request.
+They drive a real browser through the dev version of Adminer served by the PHP web server, against a database started in Docker by [Testcontainers](https://testcontainers.com/).
+The tests have a `composer.json` of their own, installed by `composer install -d tests/e2e`, so that Adminer itself keeps having no dependencies and the tests can require the PHP 8.2 that Behat and Playwright need.
+
+The scenarios are written in Gherkin and run by [Behat](https://docs.behat.org/), one suite per driver: `tests/e2e/features/shared/` describes what all drivers do and is run against each of them, `tests/e2e/features/<driver>/` what only that one has.
+The steps they are written in are in `tests/e2e/bootstrap/AdminerContext.php`, the rows they expect in `tests/e2e/seed/<driver>.sql`, which is the same data in each driver's own types.
+[tests/e2e/README.md](/tests/e2e/README.md) says how to write one.
+`composer e2e -- --suite=pgsql` runs one driver only, `composer e2e -- --name "Sorting"` a single scenario.
+`composer e2e-visual` runs everything in a browser you can watch, slowed down enough to follow.
+A step which fails leaves a screenshot and the HTML of the page in `tests/e2e/artifacts/`; the workflow uploads them.
+
 ## JavaScript
 
 Adminer functions without JavaScript but is more user-friendly when JavaScript is enabled.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,144 @@
+# End-to-end tests
+
+Scenarios written in [Gherkin](https://docs.behat.org/en/latest/user_guide/gherkin.html) and run by
+[Behat](https://docs.behat.org/), which drives a real browser through the dev version of Adminer,
+served by the PHP web server, against a database started in Docker by
+[Testcontainers](https://testcontainers.com/).
+
+They have a `composer.json` of their own, so that Adminer itself keeps having no dependencies at
+all and the tests can ask for the PHP 8.2 their own dependencies need - Adminer's sources require
+7.4 and compile down to 5.3.
+
+## Installing
+
+Docker has to be running - the databases are containers - and there are two ways to get everything
+else.
+
+**In the dev container**, which needs nothing installed but Docker and brings PHP with the database
+extensions, Composer, Node and the browser:
+
+```bash
+npx @devcontainers/cli up --workspace-folder .   # or open the repository in an IDE which reads it
+```
+
+`.devcontainer/setup.sh` then installs the rest. Commands are run inside it:
+
+```bash
+npx @devcontainers/cli exec --workspace-folder . composer e2e
+```
+
+**Or with your own PHP 8.2+**, Composer and Node:
+
+```bash
+composer install                # Adminer: no dependencies, but it initializes the submodules
+composer install -d tests/e2e   # Behat, Playwright and Testcontainers
+composer browser -d tests/e2e   # the Chromium the scenarios are run in
+```
+
+## Running
+
+From the root of the repository:
+
+```bash
+composer e2e                                   # every scenario against every driver
+composer e2e-visual                            # the same in a browser you can watch
+composer e2e -- --suite=pgsql                  # one driver only
+composer e2e -- tests/e2e/features/shared/login.feature  # one feature
+composer e2e -- --name "Sorting reorders"      # one scenario, by name
+composer e2e -- --stop-on-failure              # stop at the first failure, for a fast loop
+composer e2e -- -di                            # every step that can be written
+```
+
+In the dev container the browser draws on a desktop inside the container - it has no screen of its
+own, Playwright will not start a headed browser without one, and nothing running in there can open
+a window on the machine hosting it. Watching it is therefore a browser on <http://localhost:6080>,
+password `vscode`, and starting both is one command from the host rather than from inside:
+
+```bash
+open http://localhost:6080 &&    # macOS; xdg-open on Linux
+    npx @devcontainers/cli exec --workspace-folder . composer e2e-visual
+```
+
+Some editors open that page themselves when they forward the port; the command does not care
+either way, and neither does `composer e2e-visual` run any other way.
+
+Or `composer test -d tests/e2e`, which is the same Behat with the same configuration.
+
+A step which fails leaves a screenshot and the HTML of the page in `artifacts/`, which the
+[workflow](/.github/workflows/e2e.yml) uploads.
+
+## Layout
+
+    composer.json      the dependencies of the tests, Adminer has none
+    features/shared/   what every driver does, run against each of them
+    features/pgsql/    what only PostgreSQL has
+    features/mysql/    what only MySQL has
+    bootstrap/         AdminerContext.php - the steps they are written in
+    harness/           fixture.php - the database, the web server, the browser, logging in
+    seed/              the rows each driver starts with
+    artifacts/         what a failed step left behind, ignored by Git
+
+Where a feature sits is what decides which drivers run it, and it is the first thing to get right:
+a feature in `pgsql/` cannot be run against MySQL by forgetting anything, and a driver added later
+picks up everything in `shared/` without a single file being edited.
+
+## Adding a scenario
+
+Write it in the feature file of its subject, in steps which already exist - `behat -di` lists them
+all. A step nobody has needed yet is added to `AdminerContext`, named for what the user is doing
+rather than for what the browser is doing: `When I sort by the "name" column`, not `When I click
+the second heading`.
+
+A feature in `shared/` has to stick to what all drivers do - it is run against every one of them.
+Something a single driver has goes in the directory named after it:
+[pgsql/schema.feature](features/pgsql/schema.feature) switches PostgreSQL schemas,
+[mysql/enum.feature](features/mysql/enum.feature) edits a MySQL enum. Anything else in a step
+would be an `if` on the driver, which is the thing these directories exist to avoid.
+
+A feature which fits some drivers but not all - two of three, once there are three - is the one
+case for a tag, filtered per suite in [behat.yml](behat.yml). There is none yet, and one mechanism
+is better than two until there is.
+
+The scenarios share one database per driver and run in the order they are written, which is not an
+order to depend on: a scenario which writes starts with `Given the "notes" table is empty` and
+leaves only tables no other scenario reads.
+
+## Seed data
+
+The rows the scenarios expect are in `seed/<driver>.sql`.
+The tables the shared features read are the same in each of them, in that driver's own types; a
+table only one driver has goes after them, in that driver's file alone.
+Write the data in English, but keep the accents - they are what a broken encoding loses.
+
+## Adding a driver
+
+Add `seed/<driver>.sql` with the same tables as the others, a line to `e2e_driver()` and the
+container to `e2e_database()` in [harness/fixture.php](harness/fixture.php), a suite to
+[behat.yml](behat.yml) with a port of its own, and `features/<driver>/` when it has something the
+others do not. Everything in `features/shared/` then runs against it as it is.
+
+## Why it is set up this way
+
+**A `composer.json` of its own.** Adminer has no dependencies, and a database manager which is one
+PHP file is entitled to keep it that way; the tests need Behat, Playwright and Testcontainers, which
+is another thirty-odd packages. Keeping them here means `composer install` at the root still
+installs nothing, and the published package carries none of it. It costs a second install step.
+
+**PHP 8.2 as the floor.** The dependencies require it - Behat asks for `>=8.2 <8.6`, Playwright for
+`^8.2` - and this is a codebase Adminer's own rules do not apply to: nothing here is compiled, and
+nothing here ships, so the sources may use what the language offers rather than what a PHP 5.3
+target allows.
+
+**8.2 and not the newest.** The newest stable is PHP 8.5 and the dependencies allow it, so the
+tests are checked against the whole range (`conf/phpstan-e2e.neon` analyzes as both 8.2 and 8.5)
+and run on whatever the developer has. Requiring 8.5 would rule out everyone whose distribution
+ships something older, and for this code it would buy near nothing: it is glue - browser calls,
+string comparisons, exceptions - and the newer features have nothing to hold on to.
+
+**An IDE will still complain.** PhpStorm and IntelliJ have one PHP language level per project and
+take it from the root `composer.json`, which says 7.4 - so `#[When(...)]` and everything else newer
+than that is marked in these files even though it runs. A `composer.json` here does not change it;
+what does is either raising the language level, or restricting the "not supported in current
+language level" inspection to a scope which leaves `tests/e2e` out. The second keeps Adminer's own
+sources guarded, which is the reason the level is 7.4 in the first place.
+

--- a/tests/e2e/behat.yml
+++ b/tests/e2e/behat.yml
@@ -1,0 +1,32 @@
+# One suite per driver, so that `composer e2e` covers all of them in one run.
+#
+# Every suite runs features/shared/, which describes what all drivers do, and the directory named
+# after its driver, which describes what only that one has. The directory is what decides: a
+# feature cannot run against a driver it was not written for by forgetting a tag.
+#
+# The driver and the port of its web server are handed to the context - the suites share a
+# process, so they cannot share a port.
+
+default:
+  suites:
+    pgsql:
+      paths:
+        - "%paths.base%/features/shared"
+        - "%paths.base%/features/pgsql"
+      contexts:
+        - Adminer\Tests\AdminerContext:
+            driver: pgsql
+            port: 18080
+
+    mysql:
+      paths:
+        - "%paths.base%/features/shared"
+        - "%paths.base%/features/mysql"
+      contexts:
+        - Adminer\Tests\AdminerContext:
+            driver: mysql
+            port: 18081
+
+  formatters:
+    pretty:
+      paths: false # the steps all live in one file, naming it after each of them says nothing

--- a/tests/e2e/bootstrap/AdminerContext.php
+++ b/tests/e2e/bootstrap/AdminerContext.php
@@ -1,0 +1,295 @@
+<?php
+namespace Adminer\Tests;
+
+require_once dirname(__DIR__) . '/harness/fixture.php';
+
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Behat\Context\Context;
+use Behat\Hook\AfterScenario;
+use Behat\Hook\AfterStep;
+use Behat\Hook\BeforeScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+use Playwright\Page\PageInterface;
+use RuntimeException;
+
+/** The steps every feature is written in
+*
+* One instance per scenario, so $page is a browser nobody else has touched. The database and the
+* web server are not: they are booted once per driver and kept in $fixtures, which is by far the
+* slowest part of a run and has nothing a scenario can spoil - Adminer is stateless and the only
+* table written to is emptied by the scenario writing it.
+*
+* Which driver an instance is for comes from the Behat suite it belongs to, see tests/e2e/behat.yml.
+*/
+class AdminerContext implements Context {
+	/** @var array<string, E2eFixture> what e2e_boot() returned, per driver */
+	private static array $fixtures = array();
+
+	/** @var E2eFixture */
+	private array $fix;
+
+	private PageInterface $page;
+
+	private string $driver;
+
+	/** @var int the web server of this driver, its own so that the suites can share a process */
+	private int $port;
+
+	public function __construct(string $driver, int $port) {
+		$this->driver = $driver;
+		$this->port = $port;
+	}
+
+	#[BeforeScenario]
+	public function open(): void {
+		putenv("ADMINER_E2E_DRIVER=$this->driver"); // read by e2e_driver()
+		if (!isset(self::$fixtures[$this->driver])) {
+			self::$fixtures[$this->driver] = e2e_boot($this->port);
+		}
+		$this->fix = self::$fixtures[$this->driver];
+		$this->page = e2e_browser()->newPage();
+		$this->page->setViewportSize(1280, 900);
+	}
+
+	#[AfterScenario]
+	public function close(): void {
+		$this->page->context()->close();
+	}
+
+	/** Save the page a step failed on, so that a failure in CI is more than a line of text
+	*
+	* isset() because booting the fixture can fail before there is a page, and a second error
+	* thrown from here would be the only one reported.
+	*/
+	#[AfterStep]
+	public function report(AfterStepScope $scope): void {
+		if (!$scope->getTestResult()->isPassed() && isset($this->page)) {
+			$name = basename($scope->getFeature()->getFile(), ".feature") . "-" . $scope->getStep()->getLine();
+			e2e_report($this->page, $this->fix, $name);
+		}
+	}
+
+	#[Given('I am logged in to the demo database')]
+	public function logIn(): void {
+		e2e_login($this->page, $this->fix);
+	}
+
+	/** Arranged without the browser: the scenarios share a database, and one which writes has to
+	* start from a known state whatever ran before it
+	*/
+	#[Given('the :table table is empty')]
+	public function tableIsEmpty(string $table): void {
+		e2e_connect($this->fix['driver'], $this->fix['database'])->exec("DELETE FROM $table");
+	}
+
+	#[When('I log out')]
+	public function logOut(): void {
+		$this->page->click("#logout");
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	#[When('I open the :table table')]
+	public function openTable(string $table): void {
+		$this->go(array("select" => $table));
+	}
+
+	#[When('I open the :table table in the :schema schema')]
+	public function openTableInSchema(string $table, string $schema): void {
+		$this->go(array("ns" => $schema, "select" => $table));
+	}
+
+	#[When('I open the insert form for the :table table')]
+	public function openInsertForm(string $table): void {
+		$this->go(array("edit" => $table));
+	}
+
+	#[When('I reload the page')]
+	public function reload(): void {
+		$this->page->reload();
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	#[When('I sort by the :column column')]
+	public function sortBy(string $column): void {
+		// The heading of the column, not the search or descending link in the span next to it.
+		$this->page->click("[id=\"th[$column]\"] > a");
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	#[When('I search for :value in :column')]
+	public function search(string $value, string $column): void {
+		$this->page->click('legend a[href="#fieldset-search"]'); // the form is behind its legend
+		$this->page->locator('select[name="where[0][col]"]')->selectOption($column);
+		$this->page->locator('select[name="where[0][op]"]')->selectOption("=");
+		$this->page->locator('input[name="where[0][val]"]')->fill($value);
+		$this->page->click('input[type=submit][value="Select"]');
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	#[When('I switch to the :schema schema')]
+	public function switchSchema(string $schema): void {
+		$this->page->locator("[name=ns]")->selectOption($schema);
+		// The selector reloads the page on its own, a beat after selectOption() returns.
+		$this->page->waitForURL("**ns=$schema**");
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	/** first(), because the step says first: the selector matches the edit link of every row, and a
+	* locator which resolves to more than one is a strict mode violation, not a click on the one at
+	* the top. It only ever worked on a table holding a single row.
+	*/
+	#[When('I edit the first row')]
+	public function editFirstRow(): void {
+		$this->page->locator("#table tbody tr a.edit")->first()->click();
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	/** The columns are a textarea in one driver and an input in another, so the selectors name no tag */
+	#[When('I fill :field with :value')]
+	public function fill(string $field, string $value): void {
+		$this->page->locator("[name=\"fields[$field]\"]")->fill($value);
+	}
+
+	#[When('I pick :value for :field')]
+	public function pick(string $value, string $field): void {
+		$this->page->click("[name=\"fields[$field][]\"][value=\"val-$value\"]");
+	}
+
+	/** Save is the only submit button without a name, the others save and continue */
+	#[When('I save the form')]
+	public function save(): void {
+		$this->page->click('#form input[type=submit]:not([name])');
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	#[When('I delete the row')]
+	public function delete(): void {
+		// The button asks for a confirmation on click, which submitting the form directly skips -
+		// the dialog is the browser's, the deletion is Adminer's and that is what is being tested.
+		// Deferred, because the navigation it starts would destroy the context this runs in.
+		$this->page->evaluate(/** @lang JavaScript */ "() => {
+			const button = document.querySelector('#form [name=delete]');
+			setTimeout(() => button.form.requestSubmit(button), 0);
+		}");
+		// Adminer sends the browser to the data list once the row is gone. Waiting for that rather
+		// than for a quiet network is what makes this reliable: a deferred submit has not
+		// necessarily started navigating by the time the network first falls silent.
+		$this->page->waitForURL("**select=**");
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	#[Then('/^the table lists (\d+) rows?$/')]
+	public function tableLists(int $count): void {
+		$rows = $this->rows();
+		if (count($rows) != $count) {
+			throw new RuntimeException("the table lists " . count($rows) . " rows: " . implode(" | ", $rows));
+		}
+	}
+
+	#[Then('row :number contains :text')]
+	public function rowContains(int $number, string $text): void {
+		$rows = $this->rows();
+		$row = ($rows[$number - 1] ?? "");
+		if (strpos($row, $text) === false) {
+			throw new RuntimeException("row $number is '$row'");
+		}
+	}
+
+	#[Then('the URL contains :text')]
+	public function urlContains(string $text): void {
+		if (strpos($this->page->url(), $text) === false) {
+			throw new RuntimeException("the URL is " . $this->page->url());
+		}
+	}
+
+	/** Read through a locator, not an evaluate: a locator waits for the element and survives a page
+	* which is still navigating, where an evaluate dies as "Execution context was destroyed"
+	*/
+	#[Then('the breadcrumb shows the demo database')]
+	public function breadcrumbShowsDatabase(): void {
+		$breadcrumb = (string) $this->page->locator("#breadcrumb")->textContent();
+		if (strpos($breadcrumb, E2E_DATABASE) === false) {
+			throw new RuntimeException("the breadcrumb is '$breadcrumb', the title " . $this->page->title());
+		}
+	}
+
+	#[Then('the table list contains :table')]
+	public function tableListContains(string $table): void {
+		if (!in_array($table, $this->tables(), true)) {
+			throw new RuntimeException("the table list is " . implode(", ", $this->tables()));
+		}
+	}
+
+	#[Then('the table list does not contain :table')]
+	public function tableListDoesNotContain(string $table): void {
+		if (in_array($table, $this->tables(), true)) {
+			throw new RuntimeException("the table list is " . implode(", ", $this->tables()));
+		}
+	}
+
+	#[Then('the login form is shown')]
+	public function loginFormIsShown(): void {
+		if (!$this->page->evaluate(/** @lang JavaScript */ "() => !!document.querySelector('[name=\"auth[driver]\"]')")) {
+			throw new RuntimeException("the page is " . $this->page->title());
+		}
+	}
+
+	#[Then('the schema selector offers :schema')]
+	public function schemaSelectorOffers(string $schema): void {
+		$schemas = $this->page->evaluate(/** @lang JavaScript */ "() => Array.from(document.querySelectorAll('[name=ns] option')).map(o => o.value)");
+		if (!in_array($schema, (array) $schemas, true)) {
+			throw new RuntimeException("the schemas offered are " . implode(", ", (array) $schemas));
+		}
+	}
+
+	#[Then('the :field field offers :values')]
+	public function fieldOffers(string $field, string $values): void {
+		$offered = implode(", ", array_map(
+			function ($value) {
+				return preg_replace('~^val-~', '', $value);
+			},
+			(array) $this->page->evaluate("() => Array.from(document.querySelectorAll('[name=\"fields[$field][]\"]')).map(i => i.value)")
+		));
+		if ($offered !== $values) {
+			throw new RuntimeException("the $field field offers $offered");
+		}
+	}
+
+	#[Then('the :field field has :value picked')]
+	public function fieldHasPicked(string $field, string $value): void {
+		$picked = $this->page->evaluate("() => (document.querySelector('[name=\"fields[$field][]\"]:checked') || {}).value || 'nothing'");
+		if ($picked !== "val-$value") {
+			throw new RuntimeException("the $field field has $picked picked");
+		}
+	}
+
+	#[Then('the field :field contains :value')]
+	public function fieldContains(string $field, string $value): void {
+		$actual = $this->page->locator("[name=\"fields[$field]\"]")->inputValue();
+		if ($actual !== $value) {
+			throw new RuntimeException("the $field field contains '$actual'");
+		}
+	}
+
+	/** Go to a page of the demo database
+	* @param string[] $params
+	*/
+	private function go(array $params): void {
+		$this->page->goto(e2e_url($this->fix, $params));
+		$this->page->waitForLoadState("networkidle");
+	}
+
+	/** Get the rows as they read on the screen, whitespace collapsed the way a person sees it
+	* @return string[]
+	*/
+	private function rows(): array {
+		return (array) $this->page->evaluate(/** @lang JavaScript */ "() => Array.from(document.querySelectorAll('#table tbody tr')).map(tr => tr.textContent.replace(/\\s+/g, ' ').trim())");
+	}
+
+	/** @return string[] */
+	private function tables(): array {
+		return (array) $this->page->evaluate(/** @lang JavaScript */ "() => Array.from(document.querySelectorAll('#tables a')).map(a => a.textContent.trim())");
+	}
+}

--- a/tests/e2e/composer.json
+++ b/tests/e2e/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "vrana/adminer-e2e",
+    "description": "Adminer's browser end-to-end tests, see README.md.",
+    "type": "project",
+    "license": [
+        "Apache-2.0",
+        "GPL-2.0-only"
+    ],
+    "require": {
+        "php": ">=8.2",
+        "behat/behat": "^3.32",
+        "playwright-php/playwright": "^1.3",
+        "testcontainers/testcontainers": "^1.0.10"
+    },
+    "autoload": {
+        "psr-4": {
+            "Adminer\\Tests\\": "bootstrap/"
+        }
+    },
+    "scripts": {
+        "test": "behat",
+        "test-visual": [
+            "@putenv ADMINER_E2E_HEADED=1",
+            "behat"
+        ],
+        "browser": [
+            "@php vendor/bin/playwright-install",
+            "@php -r \"chdir('vendor/playwright-php/playwright/bin'); passthru('npx --no-install playwright install chromium');\""
+        ]
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        },
+        "process-timeout": 0
+    }
+}

--- a/tests/e2e/features/mysql/enum.feature
+++ b/tests/e2e/features/mysql/enum.feature
@@ -1,0 +1,25 @@
+Feature: Editing an enum column
+  enum is MySQL's type and Adminer treats it as one: instead of a text field, the edit form offers
+  the values the column declares as radio buttons.
+
+  Background:
+    Given I am logged in to the demo database
+
+  Scenario: A new row is offered the declared values, starting on the default
+    When I open the insert form for the "articles" table
+    Then the "status" field offers "draft, published, archived"
+    And the "status" field has "draft" picked
+
+  Scenario: An existing row is offered with its own value picked
+    When I open the "articles" table
+    And I edit the first row
+    Then the "status" field has "draft" picked
+
+  Scenario: The picked value is the one saved
+    When I open the insert form for the "articles" table
+    And I fill "title" with "Written by a scenario"
+    And I pick "archived" for "status"
+    And I save the form
+    And I open the "articles" table
+    Then row 3 contains "archived"
+    And row 3 contains "Written by a scenario"

--- a/tests/e2e/features/pgsql/schema.feature
+++ b/tests/e2e/features/pgsql/schema.feature
@@ -1,0 +1,23 @@
+Feature: Switching PostgreSQL schemas
+  PostgreSQL is the only driver here whose database holds more than one namespace, so Adminer
+  prints a Schema selector next to the database one and carries the choice in ns=. The table list,
+  the links and the data all follow from it.
+
+  Background:
+    Given I am logged in to the demo database
+
+  Scenario: Both schemas are offered and the tables of the current one are listed
+    Then the schema selector offers "analytics"
+    And the table list contains "users"
+    But the table list does not contain "reports"
+
+  Scenario: Switching the selector lists the tables of the other schema
+    When I switch to the "analytics" schema
+    Then the URL contains "ns=analytics"
+    And the table list contains "reports"
+    But the table list does not contain "users"
+
+  Scenario: The rows of the other schema are reachable
+    When I open the "reports" table in the "analytics" schema
+    Then the table lists 2 rows
+    And row 1 contains "Daily summary"

--- a/tests/e2e/features/shared/insert.feature
+++ b/tests/e2e/features/shared/insert.feature
@@ -1,0 +1,40 @@
+Feature: Inserting, editing and deleting a row
+  The round trip through the edit form. Only notes is written to, so that the scenarios reading
+  users are unaffected, and each of these starts from an empty table - they share a database and
+  run in the order they are written, which is not an order to depend on.
+
+  Background:
+    Given I am logged in to the demo database
+    And the "notes" table is empty
+
+  Scenario: A new row is saved and listed
+    When I open the insert form for the "notes" table
+    And I fill "title" with "Who watches the watchmen"
+    And I fill "body" with "Added by a scenario — em dash and all."
+    And I save the form
+    And I open the "notes" table
+    Then the table lists 1 row
+    And row 1 contains "Who watches the watchmen"
+    And row 1 contains "Added by a scenario — em dash and all."
+
+  Scenario: The edit form is offered with the saved values, and saves the changed ones
+    When I open the insert form for the "notes" table
+    And I fill "title" with "Who watches the watchmen"
+    And I save the form
+    And I open the "notes" table
+    And I edit the first row
+    Then the field "title" contains "Who watches the watchmen"
+    When I fill "title" with "Who tests the tests"
+    And I save the form
+    And I open the "notes" table
+    Then the table lists 1 row
+    And row 1 contains "Who tests the tests"
+
+  Scenario: A deleted row is gone from the list
+    When I open the insert form for the "notes" table
+    And I fill "title" with "Written to be deleted"
+    And I save the form
+    And I open the "notes" table
+    And I edit the first row
+    And I delete the row
+    Then the table lists 0 rows

--- a/tests/e2e/features/shared/login.feature
+++ b/tests/e2e/features/shared/login.feature
@@ -1,0 +1,17 @@
+Feature: Logging in and out
+  The login form is the one page every user sees, and the only one which has to work before
+  anything else can be tested. Logging out goes through the CSRF token, so a broken token shows
+  up here first.
+
+  Scenario: Logging in opens the database
+    Given I am logged in to the demo database
+    Then the breadcrumb shows the demo database
+    And the table list contains "users"
+    And the table list contains "notes"
+
+  Scenario: Logging out ends the session
+    Given I am logged in to the demo database
+    When I log out
+    Then the login form is shown
+    When I open the "users" table
+    Then the login form is shown

--- a/tests/e2e/features/shared/select.feature
+++ b/tests/e2e/features/shared/select.feature
@@ -1,0 +1,28 @@
+Feature: Listing, sorting and searching rows
+  The data list is the page Adminer is used for most. The names it lists are seeded out of
+  alphabetical order and with accents, so that sorting visibly reorders them and a broken encoding
+  fails a scenario instead of ending up in a screenshot nobody looks at.
+
+  Background:
+    Given I am logged in to the demo database
+    When I open the "users" table
+
+  Scenario: The seeded rows are listed
+    Then the table lists 6 rows
+    And row 1 contains "Diana Marsh"
+
+  Scenario: Sorting reorders the rows and says so in the URL
+    When I sort by the "name" column
+    Then the table lists 6 rows
+    And row 1 contains "Amélie Fontaine"
+    And the URL contains "order"
+
+  Scenario: A reload keeps the sorted order
+    When I sort by the "name" column
+    And I reload the page
+    Then row 1 contains "Amélie Fontaine"
+
+  Scenario: Searching narrows the list down to the matching row
+    When I search for "eero@example.com" in "email"
+    Then the table lists 1 row
+    And row 1 contains "Eero Väisälä"

--- a/tests/e2e/harness/fixture.php
+++ b/tests/e2e/harness/fixture.php
@@ -1,0 +1,263 @@
+<?php
+/** Shared fixture for the end-to-end tests
+*
+* What the scenarios in tests/e2e/features/ need before the first step can run: a seeded throwaway
+* database and the dev version of Adminer served from the repository. AdminerContext calls
+* e2e_boot() once per driver, then e2e_login() to log a page in, e2e_url() to build a link into
+* the demo database and e2e_report() to save a page a scenario failed on.
+*
+* Which driver is being tested arrives in ADMINER_E2E_DRIVER, set by the context from the Behat
+* suite it belongs to; ADMINER_E2E_SERVER points at a database which is already running, for a run
+* which should not start one of its own.
+*/
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Playwright\Browser\BrowserContextInterface;
+use Playwright\Configuration\PlaywrightConfig;
+use Playwright\Page\PageInterface;
+use Playwright\PlaywrightFactory;
+use Symfony\Component\Process\Process;
+use Testcontainers\Modules\MySQLContainer;
+use Testcontainers\Modules\PostgresContainer;
+
+const E2E_DATABASE = 'adminer_e2e';
+// Any password would do, an empty one would not: Adminer refuses to connect to a server which
+// accepts one, so the tests would never get past the login form.
+const E2E_PASSWORD = 'e2e';
+
+/** Get the driver the current process tests, and how to start, seed and log into it
+*
+* The key is what Adminer calls the driver in the URL and in the login form, which is not always
+* the name of the database - MySQL is "server" there for backwards compatibility.
+* @return E2eDriver
+*/
+function e2e_driver(): array {
+	$drivers = array(
+		// MySQLContainer's password is its own default, the one PostgresContainer takes as an argument.
+		"pgsql" => array("key" => "pgsql", "port" => 5432, "username" => "adminer", "password" => E2E_PASSWORD),
+		"mysql" => array("key" => "server", "port" => 3306, "username" => "root", "password" => "root"),
+	);
+	$name = getenv("ADMINER_E2E_DRIVER") ?: "pgsql";
+	if (!isset($drivers[$name])) {
+		throw new RuntimeException("unknown driver '$name', use " . implode(" or ", array_keys($drivers)));
+	}
+	return array("name" => $name) + $drivers[$name];
+}
+
+/** Start the database and seed it, or reuse one which is already running
+* @param E2eDriver $driver
+* @return string hostname:port to connect to
+*/
+function e2e_database(array $driver): string {
+	$running = getenv("ADMINER_E2E_SERVER");
+	if ($running) {
+		return $running;
+	}
+	// The container is named, and a name is looked up rather than a port, so that a run reuses the
+	// database a killed run left behind instead of starting one of its own - and so that it can
+	// never latch onto somebody else's database which happens to be on the port we would have
+	// picked. Whichever run starts it stops it; a reused one is left to the run which did.
+	$name = "adminer-e2e-{$driver['name']}";
+	$host = getenv("TESTCONTAINERS_HOST_OVERRIDE") ?: "127.0.0.1";
+	$server = e2e_running($name, $driver["port"], $host);
+	if (!$server) {
+		$container = ($driver["name"] == "pgsql"
+			? new PostgresContainer("18-alpine", $driver["username"], $driver["password"], E2E_DATABASE)
+			: (new MySQLContainer("8"))->withMySQLDatabase(E2E_DATABASE)
+		);
+		$started = $container->withName($name)->start();
+		register_shutdown_function(function () use ($started) {
+			$started->stop();
+		});
+		$server = $started->getHost() . ":" . $started->getMappedPort($driver["port"]);
+	}
+	// Always, reused or not: the seed drops what it creates, so this is what a rerun starts from.
+	e2e_connect($driver, $server)->exec(file_get_contents(dirname(__DIR__) . "/seed/{$driver['name']}.sql"));
+	return $server;
+}
+
+/** Get where a container of that name publishes the port, or nothing if it is not running
+* @return ?string hostname:port
+*/
+function e2e_running(string $name, int $port, string $host): ?string {
+	$published = new Process(array("docker", "port", $name, "$port/tcp"));
+	$published->run();
+	if (!$published->isSuccessful() || !preg_match('~:(\d+)~', $published->getOutput(), $match)) {
+		return null;
+	}
+	return "$host:$match[1]";
+}
+
+/** Connect to the demo database without a browser, to seed it and to arrange what a scenario needs
+* @param E2eDriver $driver
+* @param string $server hostname:port
+*/
+function e2e_connect(array $driver, string $server): PDO {
+	list($host, $port) = explode(":", $server);
+	return new PDO(
+		"{$driver['name']}:host=$host;port=$port;dbname=" . E2E_DATABASE,
+		$driver["username"],
+		$driver["password"]
+	);
+}
+
+/** Serve the dev version of Adminer and return everything a test needs
+* @return E2eFixture
+*/
+function e2e_boot(int $port = 18080): array {
+	$root = dirname(__DIR__, 3);
+	$artifacts = dirname(__DIR__) . "/artifacts";
+	@mkdir($artifacts, 0777, true);
+	$driver = e2e_driver();
+	$database = e2e_database($driver);
+
+	// The next free one, not the one asked for: a run which was killed leaves its server behind,
+	// and every scenario would then wait for a port it is never going to get.
+	$port = e2e_free_port($port);
+	$server = new Process(array(PHP_BINARY, "-S", "127.0.0.1:$port", "-t", $root));
+	// The server logs every request it serves to stderr and nothing here ever reads that pipe, so it
+	// fills - sixty-four kilobytes in, the server blocks writing to it and stops answering. From the
+	// browser that looks like a page which commits and then never finishes loading, a scenario or
+	// two into the run, and the log is of no use to a test anyway.
+	$server->disableOutput();
+	$server->start();
+
+	$base = "http://127.0.0.1:$port/adminer/";
+	$context = stream_context_create(array("http" => array("timeout" => 1, "ignore_errors" => true)));
+	$deadline = time() + 15;
+	// The login form, not merely an answer: anything else listening on the port would answer too,
+	// and every scenario would then fail at logging in to a page which is not Adminer.
+	while (strpos((string) @file_get_contents($base, false, $context), "auth[driver]") === false) {
+		if (time() > $deadline) {
+			$server->stop();
+			throw new RuntimeException("Adminer is not answering on port $port, is something else using it?");
+		}
+		usleep(200000);
+	}
+	return compact('root', 'artifacts', 'server', 'base', 'database', 'driver');
+}
+
+/** Get a port nothing is listening on yet, starting from the one asked for */
+function e2e_free_port(int $port): int {
+	for ($i = 0; $i < 20; $i++) {
+		$socket = @stream_socket_server("tcp://127.0.0.1:" . ($port + $i), $errno, $error);
+		if ($socket) {
+			fclose($socket);
+			return $port + $i;
+		}
+	}
+	throw new RuntimeException("no free port between $port and " . ($port + 19));
+}
+
+/** Build a link into the demo database
+* @param E2eFixture $fix
+* @param string[] $params e.g. array("select" => "users")
+*/
+function e2e_url(array $fix, array $params): string {
+	$connection = array(
+		$fix['driver']["key"] => $fix['database'],
+		"username" => $fix['driver']["username"],
+		"db" => E2E_DATABASE,
+	);
+	if ($fix['driver']["name"] == "pgsql") {
+		$connection["ns"] = "public"; // PostgreSQL addresses tables in a schema
+	}
+	// array_merge, so that a test can point somewhere else than the defaults above.
+	return $fix['base'] . "?" . http_build_query(array_merge($connection, $params));
+}
+
+/** Log a page into the demo database
+*
+* Verified and retried because the wait below is a guess: Adminer rebuilds the driver's fields
+* on change and a value filled in the middle of that is posted empty, which comes back as the
+* login page again. Whatever the test does next then fails on an empty page, which reads as
+* anything but a login problem.
+* @param E2eFixture $fix
+*/
+function e2e_login(PageInterface $page, array $fix): void {
+	for ($attempt = 1; $attempt <= 3; $attempt++) {
+		$page->goto($fix['base']);
+		$page->locator('select[name="auth[driver]"]')->selectOption($fix['driver']["key"]);
+		usleep(400000 * $attempt); // let the rebuild settle, and wait longer each time round
+		$page->locator('input[name="auth[server]"]')->fill($fix['database']);
+		$page->locator('input[name="auth[username]"]')->fill($fix['driver']["username"]);
+		$page->locator('input[name="auth[password]"]')->fill($fix['driver']["password"]);
+		$page->locator('input[name="auth[db]"]')->fill(E2E_DATABASE);
+		// Submit the form instead of clicking the button: the rebuild leaves the button
+		// intermittently unclickable, and this does not depend on its markup or its label.
+		$page->evaluate(/** @lang JavaScript */ "() => document.querySelector('[name=\"auth[driver]\"]').form.requestSubmit()");
+		$page->waitForLoadState("networkidle");
+		// A rejected login comes back as the login page and its title says so. title() is a driver
+		// call and survives a page which is still committing, which an evaluate() does not.
+		if (strpos($page->title(), "Login") !== 0) {
+			// Wait for the menu of the page the login lands on before handing it over. Adminer
+			// answers a good login with a redirect, and a quiet network is reached between its two
+			// requests, so returning on that alone gives the next step a page which navigates out
+			// from under it - and a step which reads through evaluate() dies there as "Execution
+			// context was destroyed". A locator waits for the element across the navigation.
+			$page->locator("#menu")->waitFor();
+			return;
+		}
+	}
+	throw new RuntimeException("could not log in after 3 attempts");
+}
+
+/** Get a browser context of this scenario's own, hidden unless the run asked to watch it
+*
+* One browser for the whole run, one context per scenario: a context is what holds the cookies, so
+* a scenario still logs in on a session nobody else has touched, but the browser and the Node
+* process driving it are started once instead of per scenario.
+*
+* `composer test-visual` sets the variable below; it shows the browser and slows it down enough to
+* follow, which is how a scenario is written and how a failing one is understood.
+*/
+function e2e_browser(): BrowserContextInterface {
+	// The client as well as the browser: it closes the connection to the Node process when it is
+	// collected, and the browser is then talking to nobody.
+	static $client = null, $browser = null;
+	if (!$browser) {
+		$headed = (bool) getenv("ADMINER_E2E_HEADED");
+		// Longer than the 30 seconds Playwright gives an action, and deliberately not equal to it:
+		// both sides default to 30, so a step which ran out of time raced the answer against our own
+		// giving up on it. The answer arrived with nobody waiting for it, the next request read the
+		// one before, and a single slow step failed the whole rest of the run instead of only itself.
+		$client = PlaywrightFactory::create(new PlaywrightConfig(timeoutMs: 60000));
+		$chromium = $client->chromium();
+		$chromium->withHeadless(!$headed)->withSlowMo($headed ? 300 : 0);
+		$browser = $chromium->launch();
+		register_shutdown_function(function () use (&$client) {
+			$client->close();
+		});
+	}
+	$context = $browser->newContext();
+	// Adminer asks adminer.org whether a newer version is out, once per browser, and remembers the
+	// answer in this cookie. A context has no cookies, so every scenario asked again - and
+	// waitForLoadState("networkidle") then waits on a request to somebody else's server before any
+	// step can run. Setting the cookie is what stops the check being emitted at all; the value is
+	// never read, only its presence.
+	$context->addCookies(array(array(
+		"name" => "adminer_version",
+		"value" => "0",
+		"domain" => "127.0.0.1",
+		"path" => "/",
+	)));
+	return $context;
+}
+
+/** Save the failed page as a picture and as HTML
+*
+* A failure in CI is otherwise a line of text about a page nobody can open anymore; the workflow
+* uploads this directory when the tests fail. Nothing here may throw - it runs while a scenario is
+* already failing and its own exception would replace the message saying what went wrong.
+* @param E2eFixture $fix
+*/
+function e2e_report(PageInterface $page, array $fix, string $name): void {
+	try {
+		$path = "{$fix['artifacts']}/{$fix['driver']['name']}-$name";
+		$page->screenshot("$path.png");
+		file_put_contents("$path.html", $page->content());
+	} catch (Throwable $e) {
+		fwrite(STDERR, "could not save the failed page: " . $e->getMessage() . "\n");
+	}
+}

--- a/tests/e2e/seed/mysql.sql
+++ b/tests/e2e/seed/mysql.sql
@@ -1,0 +1,45 @@
+-- Demo data for the end-to-end tests, applied by tests/e2e/harness/fixture.php.
+--
+-- The same tables and rows as seed/pgsql.sql - the tests in tests/e2e/ are run against every
+-- driver and compare against these, so the two files have to stay in step. Only the types
+-- differ, and only where they have to. What comes after them is MySQL's own and only
+-- tests/e2e/cases/mysql/ sees it.
+
+DROP TABLE IF EXISTS notes;
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+	id         int AUTO_INCREMENT PRIMARY KEY,
+	name       varchar(255),
+	email      varchar(255),
+	created_at date,
+	active     tinyint(1)
+);
+
+INSERT INTO users (name, email, created_at, active) VALUES
+	('Diana Marsh',     'diana@example.com',   '2026-04-27', 1),
+	('Amélie Fontaine', 'amelie@example.com',  '2026-01-04', 1),
+	('Carl Jörgensen',  'carl@example.com',    '2026-03-19', 0),
+	('Beatriz Chávez',  'beatriz@example.com', '2026-02-11', 1),
+	('Eero Väisälä',    'eero@example.com',    '2026-05-30', 1),
+	('Felix Brown',     'felix@example.com',   '2026-06-08', 0);
+
+CREATE TABLE notes (
+	id    int AUTO_INCREMENT PRIMARY KEY,
+	title varchar(255),
+	body  text
+);
+
+-- MySQL only. enum is its type and Adminer offers the allowed values as radio buttons instead
+-- of a text field, which is what tests/e2e/cases/mysql/enum.test.php checks.
+DROP TABLE IF EXISTS articles;
+
+CREATE TABLE articles (
+	id     int AUTO_INCREMENT PRIMARY KEY,
+	title  varchar(255),
+	status enum('draft', 'published', 'archived') NOT NULL DEFAULT 'draft'
+);
+
+INSERT INTO articles (title, status) VALUES
+	('Unfinished article', 'draft'),
+	('Released article',   'published');

--- a/tests/e2e/seed/pgsql.sql
+++ b/tests/e2e/seed/pgsql.sql
@@ -1,0 +1,48 @@
+-- Demo data for the end-to-end tests, applied by tests/e2e/harness/fixture.php.
+--
+-- The names are deliberately not in alphabetical order so that sorting by them visibly
+-- reorders the rows, and deliberately not ASCII so that a broken encoding shows up as a
+-- failing test instead of as a screenshot nobody looks at.
+--
+-- notes is written to by insert.test.php; everything else is read-only for the tests.
+-- seed/mysql.sql has to keep the same tables and rows, see there. What comes after them is
+-- PostgreSQL's own and only tests/e2e/cases/pgsql/ sees it.
+
+DROP TABLE IF EXISTS notes;
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+	id         serial PRIMARY KEY,
+	name       text,
+	email      text,
+	created_at date,
+	active     boolean
+);
+
+INSERT INTO users (name, email, created_at, active) VALUES
+	('Diana Marsh',     'diana@example.com',   '2026-04-27', true),
+	('Amélie Fontaine', 'amelie@example.com',  '2026-01-04', true),
+	('Carl Jörgensen',  'carl@example.com',    '2026-03-19', false),
+	('Beatriz Chávez',  'beatriz@example.com', '2026-02-11', true),
+	('Eero Väisälä',    'eero@example.com',    '2026-05-30', true),
+	('Felix Brown',     'felix@example.com',   '2026-06-08', false);
+
+CREATE TABLE notes (
+	id    serial PRIMARY KEY,
+	title text,
+	body  text
+);
+
+-- PostgreSQL only. Adminer addresses tables in a schema in this driver and in no other, which
+-- is what tests/e2e/cases/pgsql/schema.test.php switches between.
+DROP SCHEMA IF EXISTS analytics CASCADE;
+CREATE SCHEMA analytics;
+
+CREATE TABLE analytics.reports (
+	id    serial PRIMARY KEY,
+	title text
+);
+
+INSERT INTO analytics.reports (title) VALUES
+	('Daily summary'),
+	('Monthly summary');


### PR DESCRIPTION
E2E tests verify real user workflows and catch integration regressions that unit tests miss. Their value is even higher in the AI-assisted development era, where code generation is cheap but review and maintenance remain expensive. They provide maintainers with confidence that AI-generated changes preserve existing behavior before merging.

---

By the way, you should probably configure your GitHub Actions so they don't run automatically when someone from outside the repository adds a new workflow. It's a security risk (e.g. cache poisoning and similar attacks).

You can configure this in **Settings → Actions → General**. Under **"Approval for running fork pull request workflows from contributors"**, I'd recommend selecting **"Require approval for all external contributors"**. That prevents workflows from automatically running when someone outside the repository or organization submits a PR, including PRs that modify GitHub Actions workflows.

GitHub docs:
- [Managing GitHub Actions settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)
- [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)

It's also worth avoiding privileged `pull_request_target` workflows unless they're carefully designed, since they run in the context of the base repository and can introduce additional security risks if they execute untrusted code. 