### PR TITLE
PostgreSQL: Edit and delete rows of a partitioned table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Cache the assets of the compiled version in a service worker
 - MySQL: Display the check constraint clause without the extra escaping added by information_schema
 - MySQL 9: Create routines with LANGUAGE JAVASCRIPT
+- PostgreSQL: Edit and delete only the selected row of a partitioned table without a unique key, rows in the other partitions were affected too
 - MS SQL: Get the base type of a column declared with a user-defined type
 - ClickHouse: Print only errors from ClickHouse (GHSA-77qq-q8fv-x45v, regression from 6.0.0)
 - ClickHouse: Highlight the queries

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -490,7 +490,7 @@ ORDER BY datname");
 	function limit1(string $table, string $query, string $where, string $separator = "\n"): string {
 		return (preg_match('~^INTO~', $query)
 			? limit($query, $where, 1, 0, $separator)
-			: " $query" . (is_view(table_status1($table)) ? $where : $separator . "WHERE ctid = (SELECT ctid FROM " . table($table) . $where . $separator . "LIMIT 1)")
+			: " $query" . (is_view(table_status1($table)) ? $where : $separator . "WHERE (tableoid, ctid) = (SELECT tableoid, ctid FROM " . table($table) . $where . $separator . "LIMIT 1)")
 		);
 	}
 

--- a/tests/pgsql.spec.js
+++ b/tests/pgsql.spec.js
@@ -588,6 +588,29 @@ test('Partitioning', async () => {
 	await expect(page.locator('body')).toContainText('No tables.');
 });
 
+test('Partitioned rows', async () => {
+	const sql = "CREATE TABLE parts (id int, val text) PARTITION BY LIST (id);"
+		+ " CREATE TABLE parts_1 PARTITION OF parts FOR VALUES IN (1);"
+		+ " CREATE TABLE parts_2 PARTITION OF parts FOR VALUES IN (2);"
+		+ " INSERT INTO parts VALUES (1, 'one'), (2, 'two')"; // both rows are the first one in their partition, so they share the ctid
+	await goto(page, '/adminer/?pgsql=&username=ODBC&db=adminer_test&ns=public&sql=' + encodeURIComponent(sql));
+	await button(page, 'Execute').click();
+	await expect(page.locator('body')).toContainText('Query executed OK');
+	const select = '/adminer/?pgsql=&username=ODBC&db=adminer_test&ns=public&select=parts&order[0]=id';
+	await goto(page, select);
+	await link(page, 'edit').click(); // the table has no unique key, so the row is identified by the ctid, which is unique only within a partition
+	await page.locator('[name="fields[val]"]').fill('uno');
+	await button(page, 'Save').click();
+	await expect(page.locator('body')).toContainText('Item has been updated.');
+	await goto(page, select);
+	await expect(page.locator('body')).toContainText('two'); // the row in the other partition must keep its value
+	await page.locator('input[name="check[]"]').first().click();
+	await page.locator('[name="delete"]').click();
+	await expect(page.locator('body')).toContainText('1 item has been affected.');
+	await goto(page, '/adminer/?pgsql=&username=ODBC&db=adminer_test&ns=public&sql=' + encodeURIComponent('DROP TABLE parts'));
+	await button(page, 'Execute').click();
+});
+
 test('Variables', async () => {
 	await goto(page, '/adminer/?pgsql=&username=ODBC&variables=');
 	await expect(page.locator('body')).toContainText('autovacuum');


### PR DESCRIPTION
Editing or deleting a single row of a partitioned table affects one row in every partition.

`limit1()` identifies the row by its `ctid`, which is unique only within a single relation. A partitioned table is not one relation, so the condition is evaluated in each partition and matches whatever row sits at the same `(block, offset)` there. The `ctid` is used only when the row has no unique key, which is also the case where the damage goes unnoticed, because the other affected rows are unrelated to the edited one.

I hit this on a table with 64 partitions loaded without primary keys (they are created after the import for speed): deleting one row in Adminer reported 64 deleted rows, and the 63 unrelated posts were gone. It took a while to suspect the tool rather than the import.

## Reproduction

```sql
CREATE TABLE parts (id int, val text) PARTITION BY LIST (id);
CREATE TABLE parts_1 PARTITION OF parts FOR VALUES IN (1);
CREATE TABLE parts_2 PARTITION OF parts FOR VALUES IN (2);
INSERT INTO parts VALUES (1, 'one'), (2, 'two');
```

Both rows are the first one in their partition, so both have the ctid `(0,1)`. Open `parts` in Adminer, edit the row `1, one` and save: the other row becomes `uno` as well. Deleting one row reports two affected rows.

Without the UI:

```sql
SELECT count(*) FROM parts WHERE ctid = (SELECT ctid FROM parts WHERE id = 1 LIMIT 1);
-- 2, one row per partition

SELECT count(*) FROM parts WHERE (tableoid, ctid) = (SELECT tableoid, ctid FROM parts WHERE id = 1 LIMIT 1);
-- 1
```

## The change

`(tableoid, ctid)` restricts the condition to the partition holding the row.

- `tableoid` is a system column of every table, so on an ordinary table the condition still matches the same single row.
- Tables using the older `INHERITS` mechanism have the same ambiguity and are fixed too.
- Views keep taking the `is_view()` branch.
- Row-wise comparison against a subquery is long-standing PostgreSQL syntax; partitioned tables exist since PostgreSQL 10.

The test creates the table above, edits one row, checks that the row in the other partition kept its value, deletes one row and expects one affected row. It fails on the current code with `2 items have been affected.`

Verified manually on PostgreSQL 18.6 for both UPDATE and DELETE, on partitioned and ordinary tables.
